### PR TITLE
Fix/steam update

### DIFF
--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -117,7 +117,7 @@ namespace LootLocker.Requests
                 onComplete?.Invoke(LootLockerResponseFactory.SDKNotInitializedError<LootLockerVerifyResponse>());
                 return;
             }
-            LootLockerVerifyRequest verifyRequest = new LootLockerVerifyRequest(steamSessionTicket);
+            LootLockerVerifySteamRequest verifyRequest = new LootLockerVerifySteamRequest(steamSessionTicket);
             LootLockerAPIManager.Verify(verifyRequest, onComplete);
         }
 
@@ -220,7 +220,7 @@ namespace LootLocker.Requests
 
             CurrentPlatform = "steam";
 
-            LootLockerSessionRequest sessionRequest = new LootLockerSessionRequest(steamId64);
+            LootLockerSteamSessionRequest sessionRequest = new LootLockerSteamSessionRequest(steamId64);
             LootLockerAPIManager.Session(sessionRequest, onComplete);
         }
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -121,6 +121,17 @@ namespace LootLocker.Requests
             LootLockerAPIManager.Verify(verifyRequest, onComplete);
         }
 
+        public static string SteamSessionTicket(ref byte[] ticket, uint ticketSize)
+        {
+            Array.Resize(ref ticket, (int)ticketSize);
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < ticketSize; i++)
+            {
+                sb.AppendFormat("{0:x2}", ticket[i]);
+            }
+            return sb.ToString();
+        }
+
         public static void VerifyID(string deviceId, Action<LootLockerVerifyResponse> onComplete)
         {
             if (!CheckInitialized())

--- a/Runtime/Game/Requests/LootLockerSessionRequest.cs
+++ b/Runtime/Game/Requests/LootLockerSessionRequest.cs
@@ -26,6 +26,22 @@ namespace LootLocker.Requests
         {
         }
     }
+    [System.Serializable]
+    public class LootLockerSteamSessionRequest : LootLockerGetRequest
+    {
+        public string game_key => LootLockerConfig.current.apiKey?.ToString();
+        public string platform => "Steam";
+        public string player_identifier { get; private set; }
+        public string game_version => LootLockerConfig.current.game_version;
+        public bool development_mode => LootLockerConfig.current.developmentMode;
+        public LootLockerSteamSessionRequest(string player_identifier)
+        {
+            this.player_identifier = player_identifier;
+        }
+        public LootLockerSteamSessionRequest()
+        {
+        }
+    }
 
     [System.Serializable]
     public class LootLockerWhiteLabelSessionRequest : LootLockerGetRequest

--- a/Runtime/Game/Requests/LootLockerVerifyRequest.cs
+++ b/Runtime/Game/Requests/LootLockerVerifyRequest.cs
@@ -21,6 +21,15 @@ namespace LootLocker.Requests
             this.token = token;
         }
     }
+    public class LootLockerVerifySteamRequest : LootLockerVerifyRequest
+    {
+        public string platform => "Steam";
+
+        public LootLockerVerifySteamRequest(string token) : base (token) 
+        {
+            this.token = token;
+        }
+    }
 
     public class LootLockerVerifyResponse : LootLockerResponse
     {


### PR DESCRIPTION
- Adding a function to convert a steam session ticket to something that LootLocker can read
- Steam Authentication now works without the need of the platform selector