### PR TITLE
Added event for attribution for assetstore SDK

### DIFF
--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -10,6 +10,9 @@ namespace LootLocker.Admin
     {
         private static LootLockerConfig gameSettings;
         private SerializedObject m_CustomSettings;
+
+        public delegate void SendAttributionDelegate();
+        public static event SendAttributionDelegate APIKeyEnteredEvent;
         internal static SerializedObject GetSerializedSettings()
         {
             return new SerializedObject(gameSettings);
@@ -26,11 +29,23 @@ namespace LootLocker.Admin
             }
             // This function is called when the user clicks on the MyCustom element in the Settings window.
             m_CustomSettings = GetSerializedSettings();
+            // Check if API-key has been entered (more than 20 characters long)
+
         }
 
         public override void OnGUI(string searchContext)
         {
             m_CustomSettings.Update();
+
+            // For Unity Attribution
+            if (gameSettings.apiKey.Length > 20)
+            {
+                if (EditorPrefs.GetBool("attributionChecked") == false)
+                {
+                    EditorPrefs.SetBool("attributionChecked", true);
+                    APIKeyEnteredEvent?.Invoke();
+                }
+            }
 
             if (gameSettings == null)
             {

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -29,7 +29,6 @@ namespace LootLocker.Admin
             }
             // This function is called when the user clicks on the MyCustom element in the Settings window.
             m_CustomSettings = GetSerializedSettings();
-            // Check if API-key has been entered (more than 20 characters long)
 
         }
 


### PR DESCRIPTION
Firing event when API-key is longer than 20 characters, but will only fire once, unless EditorPrefs are cleared.