### PR TITLE
Deprecate platform dropdown

### DIFF
--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -156,12 +156,11 @@ namespace LootLocker
                                 response.Error = "Service Unavailable -- We're either offline for maintenance, or an error that should be solvable by calling again later was triggered.";
                                 break;
                         }
-
-                        bool isSteam = LootLockerSDKManager.GetCurrentPlatform() == "steam";
-                        if ((webRequest.responseCode == 401 || webRequest.responseCode == 403) && LootLockerConfig.current.allowTokenRefresh && !isSteam && tries < maxRetry) 
+                        
+                        if ((webRequest.responseCode == 401 || webRequest.responseCode == 403) && LootLockerConfig.current.allowTokenRefresh && CurrentPlatform.Get() != Platforms.Steam && tries < maxRetry) 
                         {
                             tries++;
-                            LootLockerSDKManager.DebugMessage("Refreshing Token, Since we could not find one. If you do not want this please turn off in the LootLocker config settings");
+                            LootLockerSDKManager.DebugMessage("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings");
                             RefreshTokenAndCompleteCall(request,(value)=> { tries = 0; OnServerResponse?.Invoke(value); });
                         }
                         else

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -104,14 +104,6 @@ namespace LootLocker.Admin
             EditorGUILayout.Space();
 
             EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("platform"));
-            if (EditorGUI.EndChangeCheck())
-            {
-                gameSettings.platform = (LootLockerConfig.platformType)m_CustomSettings.FindProperty("platform").enumValueIndex;
-            }
-            EditorGUILayout.Space();
-
-            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("developmentMode"));
 
             if (EditorGUI.EndChangeCheck())

--- a/Runtime/Game/LootLockerGameServerAPI.cs
+++ b/Runtime/Game/LootLockerGameServerAPI.cs
@@ -25,74 +25,87 @@ namespace LootLocker
 
         protected override void RefreshTokenAndCompleteCall(LootLockerServerRequest cacheServerRequest, Action<LootLockerResponse> OnServerResponse)
         {
-            string platform = LootLockerSDKManager.GetCurrentPlatform();
-
-            if (platform == Platforms.Steam)
+            switch (CurrentPlatform.Get())
             {
-                LootLockerSDKManager.DebugMessage("Token has expired and token refresh is not supported for Steam", true);
-                LootLockerResponse res = new LootLockerResponse();
-                res.statusCode = 401;
-                res.Error = "Token Expired";
-                res.hasError = true;
-                OnServerResponse?.Invoke(res);
-                return;
-            }
-
-            if (platform == Platforms.NintendoSwitch)
-            {
-                LootLockerSDKManager.DebugMessage("Token has expired and token refresh is not supported for Nintendo Switch", true);
-                LootLockerResponse res = new LootLockerResponse();
-                res.statusCode = 401;
-                res.Error = "Token Expired";
-                res.hasError = true;
-                OnServerResponse?.Invoke(res);
-                return;
-            }
-
-            if (platform == Platforms.Guest)
-            {
-                LootLockerSDKManager.StartGuestSession(response =>
+                case Platforms.Guest:
                 {
-                    CompleteCall(cacheServerRequest, OnServerResponse, response);
-                });
-                return;
-            } else if (platform == Platforms.WhiteLabel)
-            {
-                LootLockerSDKManager.StartWhiteLabelSession(response =>
-                {
-                    CompleteCall(cacheServerRequest, OnServerResponse, response);
-                });
-
-                return;
-            } else {
-                var sessionRequest = new LootLockerSessionRequest(LootLockerConfig.current.deviceID);
-                LootLockerAPIManager.Session(sessionRequest, (response) =>
-                {
-                    CompleteCall(cacheServerRequest, OnServerResponse, response);
-                });
-            }
-
-            void CompleteCall(LootLockerServerRequest newcacheServerRequest, Action<LootLockerResponse> newOnServerResponse, LootLockerSessionResponse response)
-            {
-                if (response.success)
-                {
-                    Dictionary<string, string> headers = new Dictionary<string, string>();
-                    headers.Add("x-session-token", LootLockerConfig.current.token);
-                    newcacheServerRequest.extraHeaders = headers;
-                    if (newcacheServerRequest.retryCount < 4)
+                    LootLockerSDKManager.StartGuestSession(response =>
                     {
-                        SendRequest(newcacheServerRequest, newOnServerResponse);
-                        newcacheServerRequest.retryCount++;
-                    }
-                    else
+                        CompleteCall(cacheServerRequest, OnServerResponse, response);
+                    });
+                    return;
+                }
+                case Platforms.WhiteLabel:
+                {
+                    LootLockerSDKManager.StartWhiteLabelSession(response =>
                     {
-                        LootLockerSDKManager.DebugMessage("Session refresh failed", true);
-                        LootLockerResponse res = new LootLockerResponse();
-                        res.statusCode = 401;
-                        res.Error = "Token Expired";
-                        res.hasError = true;
-                        newOnServerResponse?.Invoke(res);
-                    }
+                        CompleteCall(cacheServerRequest, OnServerResponse, response);
+                    });
+                    return;
+                }
+                case Platforms.AppleSignIn:
+                {
+                    LootLockerSDKManager.DebugMessage($"Token has expired, please refresh it", true);
+                    LootLockerResponse res = new LootLockerResponse
+                    {
+                        statusCode = 401,
+                        Error = "Token Expired",
+                        hasError = true
+                    };
+                    OnServerResponse?.Invoke(res);
+                    return;
+                }
+                case Platforms.NintendoSwitch:
+                case Platforms.Steam:
+                {
+                    LootLockerSDKManager.DebugMessage($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}", true);
+                    LootLockerResponse res = new LootLockerResponse
+                    {
+                        statusCode = 401,
+                        Error = "Token Expired",
+                        hasError = true
+                    };
+                    OnServerResponse?.Invoke(res);
+                    return;
+                }
+                case Platforms.PlayStationNetwork:
+                case Platforms.XboxOne:
+                case Platforms.AmazonLuna:
+                {
+                    var sessionRequest = new LootLockerSessionRequest(LootLockerConfig.current.deviceID);
+                    LootLockerAPIManager.Session(sessionRequest, (response) =>
+                    {
+                        CompleteCall(cacheServerRequest, OnServerResponse, response);
+                    });
+                    break;
+                }
+                case Platforms.None:
+                default:
+                {
+                    LootLockerSDKManager.DebugMessage($"Platform {CurrentPlatform.GetFriendlyString()} not supported", true);
+                    LootLockerResponse res = new LootLockerResponse
+                    {
+                        statusCode = 401,
+                        Error = $"Platform {CurrentPlatform.GetFriendlyString()} not supported",
+                        hasError = true
+                    };
+                    OnServerResponse?.Invoke(res);
+                    return;
+                }
+            }
+        }
+
+        void CompleteCall(LootLockerServerRequest newcacheServerRequest, Action<LootLockerResponse> newOnServerResponse, LootLockerSessionResponse response)
+        {
+            if (response.success)
+            {
+                Dictionary<string, string> headers = new Dictionary<string, string>();
+                headers.Add("x-session-token", LootLockerConfig.current.token);
+                newcacheServerRequest.extraHeaders = headers;
+                if (newcacheServerRequest.retryCount < 4)
+                {
+                    SendRequest(newcacheServerRequest, newOnServerResponse);
+                    newcacheServerRequest.retryCount++;
                 }
                 else
                 {
@@ -103,6 +116,15 @@ namespace LootLocker
                     res.hasError = true;
                     newOnServerResponse?.Invoke(res);
                 }
+            }
+            else
+            {
+                LootLockerSDKManager.DebugMessage("Session refresh failed", true);
+                LootLockerResponse res = new LootLockerResponse();
+                res.statusCode = 401;
+                res.Error = "Token Expired";
+                res.hasError = true;
+                newOnServerResponse?.Invoke(res);
             }
         }
     }

--- a/Runtime/Game/Platforms/PlatformManager.cs
+++ b/Runtime/Game/Platforms/PlatformManager.cs
@@ -2,16 +2,118 @@ using System;
 
 namespace LootLocker.Requests
 {
-    public static class Platforms
+    public enum Platforms
     {
-        public static string NintendoSwitch = "nintendo_switch";
-        public static string Guest = "guest";
-        public static string WhiteLabel = "white_label";
-        public static string Steam = "white_label";
+        None
+        ,Guest
+        ,WhiteLabel
+        ,Steam
+        ,PlayStationNetwork
+        ,XboxOne
+        ,NintendoSwitch
+        ,AmazonLuna
+        ,AppleSignIn
     }
 
-    public static class PlatformManager
+    public class CurrentPlatform
     {
-        private static string CurrentPlatform { get; set; }
+        static CurrentPlatform()
+        {
+            if (PlatformStrings.Length != Enum.GetNames(typeof(Platforms)).Length)
+            {
+                throw new ArrayTypeMismatchException($"A Platform is missing a string representation, {PlatformStrings.Length} vs {Enum.GetNames(typeof(Platforms)).Length}");
+            }
+            if (PlatformFriendlyStrings.Length != Enum.GetNames(typeof(Platforms)).Length)
+            {
+                throw new ArrayTypeMismatchException($"A Platform is missing a friendly name, {PlatformFriendlyStrings.Length} vs {Enum.GetNames(typeof(Platforms)).Length}");
+            }
+        }
+        
+        private static readonly string[] PlatformStrings = new[]
+        {
+            "" // None
+            ,"guest" // Guest
+            ,"white_label_login" // WhiteLabel
+            ,"steam" // Steam
+            ,"psn" // PSN
+            ,"xbox_one" // XboxOne
+            ,"nintendo_switch" // NintendoSwitch
+            ,"amazon_luna" // AmazonLuna
+            ,"apple_sign_in" // AppleSignIn
+        };
+        private static readonly string[] PlatformFriendlyStrings = new[]
+        {
+            "None" // None
+            ,"Guest" // Guest
+            ,"White Label" // WhiteLabel
+            ,"Steam" // Steam
+            ,"Playstation Network" // PSN
+            ,"Xbox One" // XboxOne
+            ,"Nintendo Switch" // NintendoSwitch
+            ,"Amazon Luna" // AmazonLuna
+            ,"Apple Sign In" // AppleSignIn
+        };
+
+        private static Platforms currentPlatform;
+        private static string currentPlatformString;
+        private static string currentPlatformFriendlyString;
+
+        public override string ToString()
+        {
+            return currentPlatformString;
+        }
+
+        public static Platforms Get()
+        {
+            return currentPlatform;
+        }
+
+        public static string GetString()
+        {
+            return currentPlatformString;
+        }
+
+        public static string GetFriendlyString()
+        {
+            return currentPlatformFriendlyString;
+        }
+
+        public static void Set(Platforms platform)
+        {
+            currentPlatform = platform;
+            currentPlatformString = PlatformStrings[(int)currentPlatform];
+            currentPlatformFriendlyString = PlatformFriendlyStrings[(int)currentPlatform];
+        }
+
+        public static void Reset()
+        {
+            currentPlatform = Platforms.None;
+            currentPlatformString = PlatformStrings[(int)currentPlatform];
+            currentPlatformFriendlyString = PlatformFriendlyStrings[(int)currentPlatform];
+        }
+
+        // TODO: Deprecated, remove in version 1.2.0
+        public static void Set(LootLockerConfig.platformType platform)
+        {
+            switch (platform)
+            {
+                case LootLockerConfig.platformType.Android:
+                    Set(Platforms.Guest);
+                    break;
+                case LootLockerConfig.platformType.iOS:
+                    Set(Platforms.AppleSignIn);
+                    break;
+                case LootLockerConfig.platformType.Steam:
+                    Set(Platforms.Steam);
+                    break;
+                case LootLockerConfig.platformType.PlayStationNetwork:
+                    Set(Platforms.PlayStationNetwork);
+                    break;
+                case LootLockerConfig.platformType.Unused:
+                default:
+                    Set(Platforms.None);
+                    break;
+            }
+        }
     }
 }

--- a/Runtime/Game/Requests/LootLockerSessionRequest.cs
+++ b/Runtime/Game/Requests/LootLockerSessionRequest.cs
@@ -13,7 +13,7 @@ namespace LootLocker.Requests
     public class LootLockerSessionRequest : LootLockerGetRequest
     {
         public string game_key => LootLockerConfig.current.apiKey?.ToString();
-        public string platform => LootLockerConfig.current.platform.ToString();
+        public string platform => CurrentPlatform.GetString();
         public string player_identifier { get; private set; }
         public string game_version => LootLockerConfig.current.game_version;
         public bool development_mode => LootLockerConfig.current.developmentMode;
@@ -24,25 +24,6 @@ namespace LootLocker.Requests
         }
 
         public LootLockerSessionRequest()
-        {
-        }
-    }
-
-    [System.Serializable]
-    public class LootLockerSteamSessionRequest : LootLockerGetRequest
-    {
-        public string game_key => LootLockerConfig.current.apiKey?.ToString();
-        public string platform => "Steam";
-        public string player_identifier { get; private set; }
-        public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
-
-        public LootLockerSteamSessionRequest(string player_identifier)
-        {
-            this.player_identifier = player_identifier;
-        }
-
-        public LootLockerSteamSessionRequest()
         {
         }
     }
@@ -184,7 +165,7 @@ namespace LootLocker
 {
     public partial class LootLockerAPIManager
     {
-        public static void Session(LootLockerGetRequest data, Action<LootLockerSessionResponse> onComplete)
+        public static void Session(LootLockerSessionRequest data, Action<LootLockerSessionResponse> onComplete)
         {
             EndPointClass endPoint = LootLockerEndPoints.authenticationRequest;
 
@@ -194,7 +175,7 @@ namespace LootLocker
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Serialize<LootLockerSessionResponse>(serverResponse);
-                LootLockerConfig.current.UpdateToken(response.session_token, (data as LootLockerSessionRequest)?.player_identifier);
+                LootLockerConfig.current.UpdateToken(response.session_token, data?.player_identifier);
                 onComplete?.Invoke(response);
             }, false);
         }

--- a/Runtime/Game/Requests/LootLockerVerifyRequest.cs
+++ b/Runtime/Game/Requests/LootLockerVerifyRequest.cs
@@ -12,7 +12,7 @@ namespace LootLocker.Requests
     public class LootLockerVerifyRequest
     {
         public string key => LootLockerConfig.current.apiKey.ToString();
-        public string platform => LootLockerConfig.current.platform.ToString();
+        public string platform => CurrentPlatform.GetString();
         public string token { get; set; }
         public bool development_mode => LootLockerConfig.current.developmentMode;
 

--- a/Runtime/Game/Requests/PlayerRequest.cs
+++ b/Runtime/Game/Requests/PlayerRequest.cs
@@ -242,7 +242,7 @@ namespace LootLocker.Requests
         {
             getRequests.Clear();
             getRequests.Add(LootLockerConfig.current.deviceID);
-            getRequests.Add(LootLockerConfig.current.platform.ToString());
+            getRequests.Add(CurrentPlatform.GetString());
         }
     }
 

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -33,6 +31,7 @@ namespace LootLocker
             {
                 // Create a new Config
                 LootLockerConfig newConfig = ScriptableObject.CreateInstance<LootLockerConfig>();
+                newConfig.platform = platformType.Unused;
 
                 // Folder needs to exist for Unity to be able to create an asset in it
                 string dir = Application.dataPath+ "/LootLockerSDK/Resources/Config";
@@ -79,19 +78,19 @@ namespace LootLocker
             }
         }
 #endif
-        public static bool CreateNewSettings(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey, DebugLevel debugLevel = DebugLevel.All, bool allowTokenRefresh = false)
+        public static bool CreateNewSettings(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey, platformType platform = platformType.Unused, DebugLevel debugLevel = DebugLevel.All, bool allowTokenRefresh = false)
         {
             _current = Get();
 
             _current.apiKey = apiKey;
             _current.game_version = gameVersion;
-            _current.platform = platform;
+            if(platform != platformType.Unused) {
+                _current.platform = platform;
+            }
             _current.developmentMode = onDevelopmentMode;
             _current.currentDebugLevel = debugLevel;
             _current.allowTokenRefresh = allowTokenRefresh;
             _current.domainKey = domainKey;
-
-            _current = settingsInstance;
 
             return true;
         }
@@ -123,8 +122,9 @@ namespace LootLocker
         public string game_version = "1.0.0.0";
         [HideInInspector]
         public string deviceID = "defaultPlayerId";
-        public platformType platform;
-        public enum platformType { Android, iOS, Steam, PlayStationNetwork }
+        [HideInInspector]
+        public platformType platform; // TODO: Deprecated, remove in version 1.2.0
+        public enum platformType { Android, iOS, Steam, PlayStationNetwork, Unused }
         public bool developmentMode = true;
         [HideInInspector]
         public string url = "https://api.lootlocker.io/game/v1";
@@ -139,9 +139,6 @@ namespace LootLocker
         public enum DebugLevel { All, ErrorOnly, NormalOnly, Off }
         public DebugLevel currentDebugLevel = DebugLevel.All;
         public bool allowTokenRefresh = true;
-
-        // This is used to override the platform when using WhiteLabel or Guest Login since they are not "real platforms"
-        public string platformOverride = "";
 
         public void UpdateToken(string _token, string _player_identifier)
         {


### PR DESCRIPTION
To do this we need to still be able to read the config properties people have previously set. But if nothing, then set the platform when the corresponding start session method is called.