### PR TITLE
Changed links to be dictionary of string, string

### DIFF
--- a/Runtime/Game/Requests/AssetRequest.cs
+++ b/Runtime/Game/Requests/AssetRequest.cs
@@ -171,7 +171,7 @@ namespace LootLocker.Requests
         public string name { get; set; }
         public object primary_color { get; set; }
         public object secondary_color { get; set; }
-        public public Dictionary<string, string> links { get; set; }
+        public Dictionary<string, string> links { get; set; }
     }
 
 

--- a/Runtime/Game/Requests/AssetRequest.cs
+++ b/Runtime/Game/Requests/AssetRequest.cs
@@ -171,7 +171,7 @@ namespace LootLocker.Requests
         public string name { get; set; }
         public object primary_color { get; set; }
         public object secondary_color { get; set; }
-        public object links { get; set; }
+        public public Dictionary<string, string> links { get; set; }
     }
 
 


### PR DESCRIPTION
The links in LootLockerVariation was of the type object, which is wrong.
The only way to use it is if you cast the object to a string and then deserialized the string into a new json from the response, which I find highly unlikely that anyone would do.
So I think it's safe for us to change this, even though it's a breaking change.