### PR TITLE
Deprecate development mode setting

### DIFF
--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -197,7 +197,7 @@ namespace LootLocker
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("domain-key", LootLockerConfig.current.domainKey);
 
-            if (LootLockerConfig.current.developmentMode)
+            if(!LootLockerConfig.current.IsPrefixedApiKey() && LootLockerConfig.current.developmentMode)
             {
                 headers.Add("is-development", "true");
             }

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -83,7 +83,7 @@ namespace LootLocker.Admin
             if (deprecatedApiKey)
             {
                 EditorGUILayout.HelpBox(
-                    "WARNING: this is a deprecated API Key, please visit https://console.lootlocker.com/settings/api-keys and generate a new one",
+                    "WARNING: this is a legacy API Key, please visit https://console.lootlocker.com/settings/api-keys and generate a new one",
                     MessageType.Warning, false);
             }
 

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -78,8 +78,17 @@ namespace LootLocker.Admin
             {
                 gameSettings.apiKey = m_CustomSettings.FindProperty("apiKey").stringValue;
             }
+
+            bool deprecatedApiKey = !gameSettings.IsPrefixedApiKey();
+            if (deprecatedApiKey)
+            {
+                EditorGUILayout.HelpBox(
+                    "WARNING: this is a deprecated API Key, please visit https://console.lootlocker.com/settings/api-keys and generate a new one",
+                    MessageType.Warning, false);
+            }
+
             var content = new GUIContent();
-            content.text = "API key can be found in `Settings > Game settings > API` in the Web Console";
+            content.text = "API key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys";
             EditorGUILayout.HelpBox(content, false);
             EditorGUILayout.Space();
 
@@ -91,7 +100,7 @@ namespace LootLocker.Admin
                 gameSettings.domainKey = m_CustomSettings.FindProperty("domainKey").stringValue;
             }
             var domainContent = new GUIContent();
-            domainContent.text = "Domain key can be found in `Settings > Game settings > API` in the Web Console";
+            domainContent.text = "Domain key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys";
             EditorGUILayout.HelpBox(domainContent, false);
             EditorGUILayout.Space();
 
@@ -100,15 +109,6 @@ namespace LootLocker.Admin
             if (EditorGUI.EndChangeCheck())
             {
                 gameSettings.game_version = m_CustomSettings.FindProperty("game_version").stringValue;
-            }
-            EditorGUILayout.Space();
-
-            EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("developmentMode"));
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                gameSettings.developmentMode = m_CustomSettings.FindProperty("developmentMode").boolValue;
             }
             EditorGUILayout.Space();
 
@@ -129,6 +129,19 @@ namespace LootLocker.Admin
                 gameSettings.allowTokenRefresh = m_CustomSettings.FindProperty("allowTokenRefresh").boolValue; 
             }
             EditorGUILayout.Space();
+
+            if (deprecatedApiKey)
+            {
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("developmentMode"));
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    gameSettings.developmentMode = m_CustomSettings.FindProperty("developmentMode").boolValue;
+                }
+
+                EditorGUILayout.Space();
+            }
         }
 
         [SettingsProvider]

--- a/Runtime/Game/Platforms/PlatformManager.cs
+++ b/Runtime/Game/Platforms/PlatformManager.cs
@@ -54,42 +54,53 @@ namespace LootLocker.Requests
             ,"Apple Sign In" // AppleSignIn
         };
 
-        private static Platforms currentPlatform;
-        private static string currentPlatformString;
-        private static string currentPlatformFriendlyString;
+        public struct PlatformRepresentation
+        {
+            public Platforms Platform;
+            public string PlatformString;
+            public string PlatformFriendlyString;
+        }
+
+        private static PlatformRepresentation current;
 
         public override string ToString()
         {
-            return currentPlatformString;
+            return current.PlatformString;
         }
 
         public static Platforms Get()
         {
-            return currentPlatform;
+            return current.Platform;
         }
 
         public static string GetString()
         {
-            return currentPlatformString;
+            return current.PlatformString;
         }
 
         public static string GetFriendlyString()
         {
-            return currentPlatformFriendlyString;
+            return current.PlatformFriendlyString;
         }
 
         public static void Set(Platforms platform)
         {
-            currentPlatform = platform;
-            currentPlatformString = PlatformStrings[(int)currentPlatform];
-            currentPlatformFriendlyString = PlatformFriendlyStrings[(int)currentPlatform];
+            current = GetPlatformRepresentation(platform);
         }
 
         public static void Reset()
         {
-            currentPlatform = Platforms.None;
-            currentPlatformString = PlatformStrings[(int)currentPlatform];
-            currentPlatformFriendlyString = PlatformFriendlyStrings[(int)currentPlatform];
+            current = GetPlatformRepresentation(Platforms.None);
+        }
+
+        public static PlatformRepresentation GetPlatformRepresentation(Platforms platform)
+        {
+            return new PlatformRepresentation
+            {
+                Platform = platform,
+                PlatformString = PlatformStrings[(int)platform],
+                PlatformFriendlyString = PlatformFriendlyStrings[(int)platform]
+            };
         }
 
         // TODO: Deprecated, remove in version 1.2.0

--- a/Runtime/Game/Requests/LootLockerSessionRequest.cs
+++ b/Runtime/Game/Requests/LootLockerSessionRequest.cs
@@ -16,7 +16,6 @@ namespace LootLocker.Requests
         public string platform => CurrentPlatform.GetString();
         public string player_identifier { get; private set; }
         public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
         public LootLockerSessionRequest(string player_identifier)
         {
@@ -36,9 +35,8 @@ namespace LootLocker.Requests
         public string password { get; set; } // DEPRECATED PARAMETER
         public string token { get; set; }
         public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
-        [ObsoleteAttribute("StartWhiteLabelSession with password is deprecated")]
+        [Obsolete("StartWhiteLabelSession with password is deprecated")]
         public LootLockerWhiteLabelSessionRequest(string email, string password, string token)
         {
             this.email = email;
@@ -46,7 +44,7 @@ namespace LootLocker.Requests
             this.token = token;
         }
 
-        [ObsoleteAttribute("StartWhiteLabelSession with password is deprecated")]
+        [Obsolete("StartWhiteLabelSession with password is deprecated")]
         public LootLockerWhiteLabelSessionRequest(string email, string password)
         {
             this.email = email;
@@ -113,7 +111,6 @@ namespace LootLocker.Requests
         public string game_key => LootLockerConfig.current.apiKey?.ToString();
         public string nsa_id_token { get; private set; }
         public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
         public LootLockerNintendoSwitchSessionRequest(string nsa_id_token)
         {
@@ -126,7 +123,6 @@ namespace LootLocker.Requests
         public string game_key => LootLockerConfig.current.apiKey?.ToString();
         public string xbox_user_token { get; private set; }
         public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
         public LootLockerXboxOneSessionRequest(string xbox_user_token)
         {
@@ -139,7 +135,6 @@ namespace LootLocker.Requests
         public string game_key => LootLockerConfig.current.apiKey?.ToString();
         public string apple_authorization_code { get; private set; }
         public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
         public LootLockerAppleSignInSessionRequest(string apple_authorization_code)
         {
@@ -152,7 +147,6 @@ namespace LootLocker.Requests
         public string game_key => LootLockerConfig.current.apiKey?.ToString();
         public string refresh_token { get; private set; }
         public string game_version => LootLockerConfig.current.game_version;
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
         public LootLockerAppleRefreshSessionRequest(string refresh_token)
         {
@@ -172,6 +166,7 @@ namespace LootLocker
             string json = "";
             if (data == null) return;
             else json = JsonConvert.SerializeObject(data);
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Serialize<LootLockerSessionResponse>(serverResponse);
@@ -187,6 +182,7 @@ namespace LootLocker
             string json = "";
             if (data == null) return;
             else json = JsonConvert.SerializeObject(data);
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Serialize<LootLockerSessionResponse>(serverResponse);
@@ -195,7 +191,7 @@ namespace LootLocker
             }, false);
         }
 
-        public static void GuestSession(LootLockerGetRequest data, Action<LootLockerGuestSessionResponse> onComplete)
+        public static void GuestSession(LootLockerSessionRequest data, Action<LootLockerGuestSessionResponse> onComplete)
         {
             EndPointClass endPoint = LootLockerEndPoints.guestSessionRequest;
 
@@ -206,6 +202,7 @@ namespace LootLocker
             }
 
             json = JsonConvert.SerializeObject(data);
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Serialize<LootLockerGuestSessionResponse>(serverResponse);
@@ -225,6 +222,8 @@ namespace LootLocker
             }
 
             json = JsonConvert.SerializeObject(data);
+
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Serialize<LootLockerGuestSessionResponse>(serverResponse);
@@ -244,6 +243,7 @@ namespace LootLocker
             }
 
             json = JsonConvert.SerializeObject(data);
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Serialize<LootLockerSessionResponse>(serverResponse);
@@ -281,7 +281,7 @@ namespace LootLocker
             {
                 return;
             }
-
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerAppleSessionResponse.Serialize<LootLockerAppleSessionResponse>(serverResponse);
@@ -290,13 +290,14 @@ namespace LootLocker
             }, false);
         }
 
-        public static void EndSession(LootLockerGetRequest data, Action<LootLockerSessionResponse> onComplete)
+        public static void EndSession(LootLockerSessionRequest data, Action<LootLockerSessionResponse> onComplete)
         {
             EndPointClass endPoint = LootLockerEndPoints.endingSession;
 
             string json = "";
             if (data == null) return;
             else json = JsonConvert.SerializeObject(data);
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
 
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Serialize(onComplete, serverResponse); });
         }

--- a/Runtime/Game/Requests/LootLockerVerifyRequest.cs
+++ b/Runtime/Game/Requests/LootLockerVerifyRequest.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
 using LootLocker.Requests;
 
 
@@ -11,10 +7,9 @@ namespace LootLocker.Requests
 {
     public class LootLockerVerifyRequest
     {
-        public string key => LootLockerConfig.current.apiKey.ToString();
+        public string key => LootLockerConfig.current.apiKey;
         public string platform => CurrentPlatform.GetString();
         public string token { get; set; }
-        public bool development_mode => LootLockerConfig.current.developmentMode;
 
         public LootLockerVerifyRequest(string token)
         {
@@ -24,7 +19,7 @@ namespace LootLocker.Requests
 
     public class LootLockerVerifySteamRequest : LootLockerVerifyRequest
     {
-        public new string platform => "Steam";
+        public new string platform => CurrentPlatform.GetPlatformRepresentation(Platforms.Steam).PlatformString;
 
         public LootLockerVerifySteamRequest(string token) : base(token)
         {
@@ -45,8 +40,8 @@ namespace LootLocker
         {
             string json = "";
             if (data == null) return;
-            else json = JsonConvert.SerializeObject(data);
-
+            json = JsonConvert.SerializeObject(data);
+            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             EndPointClass endPoint = LootLockerEndPoints.playerVerification;
 
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Serialize(onComplete, serverResponse); }, false);

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -95,6 +95,23 @@ namespace LootLocker
             return true;
         }
 
+        // TODO: Deprecated, remove in version 1.2.0
+        public bool IsPrefixedApiKey()
+        {
+            return !string.IsNullOrEmpty(apiKey) && (apiKey.StartsWith("dev_") || apiKey.StartsWith("prod_"));
+        }
+
+        // TODO: Deprecated, remove in version 1.2.0
+        public static void AddDevelopmentModeFieldToJsonStringIfNeeded(ref string json)
+        {
+            if (!current.IsPrefixedApiKey())
+            {
+                json = json.Remove(json.Length - 1, 1); // Remove '}'
+                string devModeJsonString = ", \"development_mode\": " + current.developmentMode;
+                json = json + devModeJsonString.ToLower() + "}";
+            }
+        }
+
         private static LootLockerConfig _current;
 
         public static LootLockerConfig current
@@ -125,6 +142,7 @@ namespace LootLocker
         [HideInInspector]
         public platformType platform; // TODO: Deprecated, remove in version 1.2.0
         public enum platformType { Android, iOS, Steam, PlayStationNetwork, Unused }
+        [HideInInspector]
         public bool developmentMode = true;
         [HideInInspector]
         public string url = "https://api.lootlocker.io/game/v1";
@@ -145,6 +163,5 @@ namespace LootLocker
             token = _token;
             deviceID = _player_identifier;
         }
-
     }
 }


### PR DESCRIPTION
Since our users will continue using it for the foreseeable future; present a warning in the settings when a deprecated stype api key is used and deal with the flag handling behind the scenes.

Example when an old style API key is used:
![old_Example](https://user-images.githubusercontent.com/4068377/214280009-f4b38026-8ad0-4b4f-892e-d52551b2b8cb.png)

Example with dev key:
![dev_Example](https://user-images.githubusercontent.com/4068377/214280034-06dae4eb-6317-4b1d-ad6f-1331e227365c.png)

Example with prod key:
![prod_Example](https://user-images.githubusercontent.com/4068377/214280067-20a5ceb7-95b9-46a3-b6bc-85e2d8ffe7ed.png)
