### PR TITLE
Errors are now being logged as errors in the Unity console

### DIFF
--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -85,7 +85,7 @@ namespace LootLocker
                         yield return null;
                         if (Time.time - startTime >= maxTimeOut)
                         {
-                            LootLockerSDKManager.DebugMessage("ERROR: Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, true);
+                            LootLockerSDKManager.DebugMessage("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, true);
                             OnServerResponse?.Invoke(new LootLockerResponse() { hasError = true, statusCode = 408, Error = "{\"error\": \"" + request.endpoint + " Timed out.\"}" });
                             yield break;
                         }
@@ -172,7 +172,7 @@ namespace LootLocker
                             response.hasError = true;
                             response.text = webRequest.downloadHandler.text;
                             OnServerResponse?.Invoke(response);
-                            LootLockerSDKManager.DebugMessage(response.Error, true);
+                            LootLockerSDKManager.DebugMessage(ObfuscateJsonStringForLogging(response.Error), true);
                         }
 
                     }
@@ -278,13 +278,12 @@ namespace LootLocker
                         byte[] formSections = UnityWebRequest.SerializeFormSections(form, boundary);
                         // Set the content type - NO QUOTES around the boundary
                         string contentType = String.Concat("multipart/form-data; boundary=--", Encoding.UTF8.GetString(boundary));
-
-                        //Debug.LogError("Content type Set: " + contentType);
+                        
                         // Make my request object and add the raw body. Set anything else you need here
                         webRequest = new UnityWebRequest();
                         webRequest.SetRequestHeader("Content-Type", "multipart/form-data; boundary=--");
                         webRequest.uri = new Uri(url);
-                        Debug.Log(url);//the url is wrong in some cases
+                        LootLockerSDKManager.DebugMessage(url);//the url is wrong in some cases
                         webRequest.uploadHandler = new UploadHandlerRaw(formSections);
                         webRequest.uploadHandler.contentType = contentType;
                         webRequest.useHttpContinue = false;

--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -69,7 +69,7 @@ namespace LootLocker
                 //Build the URL that we will hit based on the specified endpoint, query params, etc
                 string url = BuildURL(request.endpoint, request.queryParams);
 #if UNITY_EDITOR
-                LootLockerLogger.EditorMessage("ServerRequest URL: " + url);
+                LootLockerLogger.EditorMessage("ServerRequest URL: " + url, LootLockerLogger.LogLevel.Verbose);
 #endif
 
                 using (UnityWebRequest webRequest = CreateWebRequest(url, request))
@@ -85,7 +85,7 @@ namespace LootLocker
                         yield return null;
                         if (Time.time - startTime >= maxTimeOut)
                         {
-                            LootLockerLogger.EditorMessage("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, true);
+                            LootLockerLogger.EditorMessage("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, LootLockerLogger.LogLevel.Error);
                             OnServerResponse?.Invoke(new LootLockerResponse() { hasError = true, statusCode = 408, Error = "{\"error\": \"" + request.endpoint + " Timed out.\"}" });
                             yield break;
                         }
@@ -99,13 +99,13 @@ namespace LootLocker
 
                     try
                     {
-                        LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + ObfuscateJsonStringForLogging(webRequest.downloadHandler.text));
+                        LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), LootLockerLogger.LogLevel.Verbose);
                     }
                     catch
                     {
-                        LootLockerLogger.EditorMessage(request.httpMethod.ToString(), true);
-                        LootLockerLogger.EditorMessage(request.endpoint, true);
-                        LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), true);
+                        LootLockerLogger.EditorMessage(request.httpMethod.ToString(), LootLockerLogger.LogLevel.Error);
+                        LootLockerLogger.EditorMessage(request.endpoint, LootLockerLogger.LogLevel.Error);
+                        LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), LootLockerLogger.LogLevel.Error);
                     }
 
                     LootLockerResponse response = new LootLockerResponse();
@@ -160,7 +160,7 @@ namespace LootLocker
                         if ((webRequest.responseCode == 401 || webRequest.responseCode == 403) && LootLockerConfig.current.allowTokenRefresh && CurrentPlatform.Get() != Platforms.Steam && tries < maxRetry) 
                         {
                             tries++;
-                            LootLockerLogger.EditorMessage("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings", true);
+                            LootLockerLogger.EditorMessage("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings", LootLockerLogger.LogLevel.Warning);
                             RefreshTokenAndCompleteCall(request,(value)=> { tries = 0; OnServerResponse?.Invoke(value); });
                         }
                         else
@@ -172,7 +172,7 @@ namespace LootLocker
                             response.hasError = true;
                             response.text = webRequest.downloadHandler.text;
                             OnServerResponse?.Invoke(response);
-                            LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(response.Error), true);
+                            LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(response.Error), LootLockerLogger.LogLevel.Error);
                         }
 
                     }
@@ -180,13 +180,13 @@ namespace LootLocker
                     {
                         try
                         {
-                            LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + webRequest.downloadHandler.text);
+                            LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + webRequest.downloadHandler.text, LootLockerLogger.LogLevel.Verbose);
                         }
                         catch
                         {
-                            LootLockerLogger.EditorMessage(request.httpMethod.ToString(), true);
-                            LootLockerLogger.EditorMessage(request.endpoint, true);
-                            LootLockerLogger.EditorMessage(webRequest.downloadHandler.text, true);
+                            LootLockerLogger.EditorMessage(request.httpMethod.ToString(), LootLockerLogger.LogLevel.Error);
+                            LootLockerLogger.EditorMessage(request.endpoint, LootLockerLogger.LogLevel.Error);
+                            LootLockerLogger.EditorMessage(webRequest.downloadHandler.text, LootLockerLogger.LogLevel.Error);
                         }
                         
                         response.success = true;
@@ -246,7 +246,7 @@ namespace LootLocker
 
                 if (texture == null)
                 {
-                    LootLockerLogger.EditorMessage("Texture download failed for: " + url, true);
+                    LootLockerLogger.EditorMessage("Texture download failed for: " + url, LootLockerLogger.LogLevel.Error);
                 }
 
                 OnComplete?.Invoke(texture);
@@ -283,7 +283,7 @@ namespace LootLocker
                         webRequest = new UnityWebRequest();
                         webRequest.SetRequestHeader("Content-Type", "multipart/form-data; boundary=--");
                         webRequest.uri = new Uri(url);
-                        LootLockerLogger.EditorMessage(url);//the url is wrong in some cases
+                        LootLockerLogger.EditorMessage(url, LootLockerLogger.LogLevel.Verbose);//the url is wrong in some cases
                         webRequest.uploadHandler = new UploadHandlerRaw(formSections);
                         webRequest.uploadHandler.contentType = contentType;
                         webRequest.useHttpContinue = false;
@@ -295,7 +295,7 @@ namespace LootLocker
                     {
                         string json = (request.payload != null && request.payload.Count > 0) ? JsonConvert.SerializeObject(request.payload) : request.jsonPayload;
 #if UNITY_EDITOR
-                        LootLockerLogger.EditorMessage("REQUEST BODY = " + ObfuscateJsonStringForLogging(json));
+                        LootLockerLogger.EditorMessage("REQUEST BODY = " + ObfuscateJsonStringForLogging(json), LootLockerLogger.LogLevel.Verbose);
 #endif
                         byte[] bytes = System.Text.Encoding.UTF8.GetBytes(string.IsNullOrEmpty(json) ? "{}" : json);
                         webRequest = UnityWebRequest.Put(url, bytes);

--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -69,7 +69,7 @@ namespace LootLocker
                 //Build the URL that we will hit based on the specified endpoint, query params, etc
                 string url = BuildURL(request.endpoint, request.queryParams);
 #if UNITY_EDITOR
-                LootLockerSDKManager.DebugMessage("ServerRequest URL: " + url);
+                LootLockerLogger.EditorMessage("ServerRequest URL: " + url);
 #endif
 
                 using (UnityWebRequest webRequest = CreateWebRequest(url, request))
@@ -85,7 +85,7 @@ namespace LootLocker
                         yield return null;
                         if (Time.time - startTime >= maxTimeOut)
                         {
-                            LootLockerSDKManager.DebugMessage("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, true);
+                            LootLockerLogger.EditorMessage("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, true);
                             OnServerResponse?.Invoke(new LootLockerResponse() { hasError = true, statusCode = 408, Error = "{\"error\": \"" + request.endpoint + " Timed out.\"}" });
                             yield break;
                         }
@@ -99,13 +99,13 @@ namespace LootLocker
 
                     try
                     {
-                        LootLockerSDKManager.DebugMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + ObfuscateJsonStringForLogging(webRequest.downloadHandler.text));
+                        LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + ObfuscateJsonStringForLogging(webRequest.downloadHandler.text));
                     }
                     catch
                     {
-                        LootLockerSDKManager.DebugMessage(request.httpMethod.ToString(), true);
-                        LootLockerSDKManager.DebugMessage(request.endpoint, true);
-                        LootLockerSDKManager.DebugMessage(ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), true);
+                        LootLockerLogger.EditorMessage(request.httpMethod.ToString(), true);
+                        LootLockerLogger.EditorMessage(request.endpoint, true);
+                        LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), true);
                     }
 
                     LootLockerResponse response = new LootLockerResponse();
@@ -160,7 +160,7 @@ namespace LootLocker
                         if ((webRequest.responseCode == 401 || webRequest.responseCode == 403) && LootLockerConfig.current.allowTokenRefresh && CurrentPlatform.Get() != Platforms.Steam && tries < maxRetry) 
                         {
                             tries++;
-                            LootLockerSDKManager.DebugMessage("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings", true);
+                            LootLockerLogger.EditorMessage("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings", true);
                             RefreshTokenAndCompleteCall(request,(value)=> { tries = 0; OnServerResponse?.Invoke(value); });
                         }
                         else
@@ -172,7 +172,7 @@ namespace LootLocker
                             response.hasError = true;
                             response.text = webRequest.downloadHandler.text;
                             OnServerResponse?.Invoke(response);
-                            LootLockerSDKManager.DebugMessage(ObfuscateJsonStringForLogging(response.Error), true);
+                            LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(response.Error), true);
                         }
 
                     }
@@ -180,13 +180,13 @@ namespace LootLocker
                     {
                         try
                         {
-                            LootLockerSDKManager.DebugMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + webRequest.downloadHandler.text);
+                            LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + webRequest.downloadHandler.text);
                         }
                         catch
                         {
-                            LootLockerSDKManager.DebugMessage(request.httpMethod.ToString(), true);
-                            LootLockerSDKManager.DebugMessage(request.endpoint, true);
-                            LootLockerSDKManager.DebugMessage(webRequest.downloadHandler.text, true);
+                            LootLockerLogger.EditorMessage(request.httpMethod.ToString(), true);
+                            LootLockerLogger.EditorMessage(request.endpoint, true);
+                            LootLockerLogger.EditorMessage(webRequest.downloadHandler.text, true);
                         }
                         
                         response.success = true;
@@ -246,7 +246,7 @@ namespace LootLocker
 
                 if (texture == null)
                 {
-                    LootLockerSDKManager.DebugMessage("Texture download failed for: " + url, true);
+                    LootLockerLogger.EditorMessage("Texture download failed for: " + url, true);
                 }
 
                 OnComplete?.Invoke(texture);
@@ -283,7 +283,7 @@ namespace LootLocker
                         webRequest = new UnityWebRequest();
                         webRequest.SetRequestHeader("Content-Type", "multipart/form-data; boundary=--");
                         webRequest.uri = new Uri(url);
-                        LootLockerSDKManager.DebugMessage(url);//the url is wrong in some cases
+                        LootLockerLogger.EditorMessage(url);//the url is wrong in some cases
                         webRequest.uploadHandler = new UploadHandlerRaw(formSections);
                         webRequest.uploadHandler.contentType = contentType;
                         webRequest.useHttpContinue = false;
@@ -295,7 +295,7 @@ namespace LootLocker
                     {
                         string json = (request.payload != null && request.payload.Count > 0) ? JsonConvert.SerializeObject(request.payload) : request.jsonPayload;
 #if UNITY_EDITOR
-                        LootLockerSDKManager.DebugMessage("REQUEST BODY = " + ObfuscateJsonStringForLogging(json));
+                        LootLockerLogger.EditorMessage("REQUEST BODY = " + ObfuscateJsonStringForLogging(json));
 #endif
                         byte[] bytes = System.Text.Encoding.UTF8.GetBytes(string.IsNullOrEmpty(json) ? "{}" : json);
                         webRequest = UnityWebRequest.Put(url, bytes);

--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -69,7 +69,7 @@ namespace LootLocker
                 //Build the URL that we will hit based on the specified endpoint, query params, etc
                 string url = BuildURL(request.endpoint, request.queryParams);
 #if UNITY_EDITOR
-                LootLockerLogger.EditorMessage("ServerRequest URL: " + url, LootLockerLogger.LogLevel.Verbose);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)("ServerRequest URL: " + url);
 #endif
 
                 using (UnityWebRequest webRequest = CreateWebRequest(url, request))
@@ -85,7 +85,7 @@ namespace LootLocker
                         yield return null;
                         if (Time.time - startTime >= maxTimeOut)
                         {
-                            LootLockerLogger.EditorMessage("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url, LootLockerLogger.LogLevel.Error);
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Exceeded maxTimeOut waiting for a response from " + request.httpMethod.ToString() + " " + url);
                             OnServerResponse?.Invoke(new LootLockerResponse() { hasError = true, statusCode = 408, Error = "{\"error\": \"" + request.endpoint + " Timed out.\"}" });
                             yield break;
                         }
@@ -99,13 +99,13 @@ namespace LootLocker
 
                     try
                     {
-                        LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), LootLockerLogger.LogLevel.Verbose);
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + ObfuscateJsonStringForLogging(webRequest.downloadHandler.text));
                     }
                     catch
                     {
-                        LootLockerLogger.EditorMessage(request.httpMethod.ToString(), LootLockerLogger.LogLevel.Error);
-                        LootLockerLogger.EditorMessage(request.endpoint, LootLockerLogger.LogLevel.Error);
-                        LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(webRequest.downloadHandler.text), LootLockerLogger.LogLevel.Error);
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(request.httpMethod.ToString());
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(request.endpoint);
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(ObfuscateJsonStringForLogging(webRequest.downloadHandler.text));
                     }
 
                     LootLockerResponse response = new LootLockerResponse();
@@ -160,7 +160,7 @@ namespace LootLocker
                         if ((webRequest.responseCode == 401 || webRequest.responseCode == 403) && LootLockerConfig.current.allowTokenRefresh && CurrentPlatform.Get() != Platforms.Steam && tries < maxRetry) 
                         {
                             tries++;
-                            LootLockerLogger.EditorMessage("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings", LootLockerLogger.LogLevel.Warning);
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Refreshing Token, since we could not find one. If you do not want this please turn off in the LootLocker config settings");
                             RefreshTokenAndCompleteCall(request,(value)=> { tries = 0; OnServerResponse?.Invoke(value); });
                         }
                         else
@@ -172,7 +172,7 @@ namespace LootLocker
                             response.hasError = true;
                             response.text = webRequest.downloadHandler.text;
                             OnServerResponse?.Invoke(response);
-                            LootLockerLogger.EditorMessage(ObfuscateJsonStringForLogging(response.Error), LootLockerLogger.LogLevel.Error);
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(ObfuscateJsonStringForLogging(response.Error));
                         }
 
                     }
@@ -180,13 +180,13 @@ namespace LootLocker
                     {
                         try
                         {
-                            LootLockerLogger.EditorMessage("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + webRequest.downloadHandler.text, LootLockerLogger.LogLevel.Verbose);
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)("Server Response: " + request.httpMethod + " " + request.endpoint + " completed in " + (Time.time - startTime).ToString("n4") + " secs.\nResponse: " + webRequest.downloadHandler.text);
                         }
                         catch
                         {
-                            LootLockerLogger.EditorMessage(request.httpMethod.ToString(), LootLockerLogger.LogLevel.Error);
-                            LootLockerLogger.EditorMessage(request.endpoint, LootLockerLogger.LogLevel.Error);
-                            LootLockerLogger.EditorMessage(webRequest.downloadHandler.text, LootLockerLogger.LogLevel.Error);
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(request.httpMethod.ToString());
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(request.endpoint);
+                            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)(webRequest.downloadHandler.text);
                         }
                         
                         response.success = true;
@@ -246,7 +246,7 @@ namespace LootLocker
 
                 if (texture == null)
                 {
-                    LootLockerLogger.EditorMessage("Texture download failed for: " + url, LootLockerLogger.LogLevel.Error);
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Texture download failed for: " + url);
                 }
 
                 OnComplete?.Invoke(texture);
@@ -283,7 +283,7 @@ namespace LootLocker
                         webRequest = new UnityWebRequest();
                         webRequest.SetRequestHeader("Content-Type", "multipart/form-data; boundary=--");
                         webRequest.uri = new Uri(url);
-                        LootLockerLogger.EditorMessage(url, LootLockerLogger.LogLevel.Verbose);//the url is wrong in some cases
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)(url);//the url is wrong in some cases
                         webRequest.uploadHandler = new UploadHandlerRaw(formSections);
                         webRequest.uploadHandler.contentType = contentType;
                         webRequest.useHttpContinue = false;
@@ -295,7 +295,7 @@ namespace LootLocker
                     {
                         string json = (request.payload != null && request.payload.Count > 0) ? JsonConvert.SerializeObject(request.payload) : request.jsonPayload;
 #if UNITY_EDITOR
-                        LootLockerLogger.EditorMessage("REQUEST BODY = " + ObfuscateJsonStringForLogging(json), LootLockerLogger.LogLevel.Verbose);
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)("REQUEST BODY = " + ObfuscateJsonStringForLogging(json));
 #endif
                         byte[] bytes = System.Text.Encoding.UTF8.GetBytes(string.IsNullOrEmpty(json) ? "{}" : json);
                         webRequest = UnityWebRequest.Put(url, bytes);

--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -156,7 +156,7 @@ namespace LootLocker
             LootLocker.LootLockerEnums.LootLockerCallerRole callerRole = LootLocker.LootLockerEnums.LootLockerCallerRole.User)
         {
 #if UNITY_EDITOR
-            LootLockerSDKManager.DebugMessage("Caller Type: " + callerRole.ToString());
+            LootLockerSDKManager.DebugMessage("Caller Type: " + callerRole);
 #endif
 
             Dictionary<string, string> headers = new Dictionary<string, string>();

--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -156,7 +156,7 @@ namespace LootLocker
             LootLocker.LootLockerEnums.LootLockerCallerRole callerRole = LootLocker.LootLockerEnums.LootLockerCallerRole.User)
         {
 #if UNITY_EDITOR
-            LootLockerSDKManager.DebugMessage("Caller Type: " + callerRole);
+            LootLockerLogger.EditorMessage("Caller Type: " + callerRole);
 #endif
 
             Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -187,7 +187,7 @@ namespace LootLocker
             if (LootLockerConfig.current.domainKey.ToString().Length == 0)
             {
 #if UNITY_EDITOR
-                LootLockerSDKManager.DebugMessage("LootLocker domain key must be set in settings", true);
+                LootLockerLogger.EditorMessage("LootLocker domain key must be set in settings", true);
 #endif
                 onComplete?.Invoke(LootLockerResponseFactory.Error<LootLockerResponse>("LootLocker domain key must be set in settings"));
 
@@ -261,7 +261,7 @@ namespace LootLocker
 
             if (this.payload != null && isNonPayloadMethod)
             {
-                LootLockerSDKManager.DebugMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
+                LootLockerLogger.EditorMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
             }
         }
 
@@ -283,7 +283,7 @@ namespace LootLocker
             this.form = null;
             if (this.payload != null && isNonPayloadMethod)
             {
-                LootLockerSDKManager.DebugMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
+                LootLockerLogger.EditorMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
             }
         }
 
@@ -305,7 +305,7 @@ namespace LootLocker
             this.form = null;
             if (!string.IsNullOrEmpty(jsonPayload) && isNonPayloadMethod)
             {
-                LootLockerSDKManager.DebugMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
+                LootLockerLogger.EditorMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
             }
         }
 

--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -156,7 +156,7 @@ namespace LootLocker
             LootLocker.LootLockerEnums.LootLockerCallerRole callerRole = LootLocker.LootLockerEnums.LootLockerCallerRole.User)
         {
 #if UNITY_EDITOR
-            LootLockerLogger.EditorMessage("Caller Type: " + callerRole, LootLockerLogger.LogLevel.Verbose);
+            LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)("Caller Type: " + callerRole);
 #endif
 
             Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -187,7 +187,7 @@ namespace LootLocker
             if (LootLockerConfig.current.domainKey.ToString().Length == 0)
             {
 #if UNITY_EDITOR
-                LootLockerLogger.EditorMessage("LootLocker domain key must be set in settings", LootLockerLogger.LogLevel.Error);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("LootLocker domain key must be set in settings");
 #endif
                 onComplete?.Invoke(LootLockerResponseFactory.Error<LootLockerResponse>("LootLocker domain key must be set in settings"));
 
@@ -261,7 +261,7 @@ namespace LootLocker
 
             if (this.payload != null && isNonPayloadMethod)
             {
-                LootLockerLogger.EditorMessage("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint, LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
             }
         }
 
@@ -283,7 +283,7 @@ namespace LootLocker
             this.form = null;
             if (this.payload != null && isNonPayloadMethod)
             {
-                LootLockerLogger.EditorMessage("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint, LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
             }
         }
 
@@ -305,7 +305,7 @@ namespace LootLocker
             this.form = null;
             if (!string.IsNullOrEmpty(jsonPayload) && isNonPayloadMethod)
             {
-                LootLockerLogger.EditorMessage("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint, LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
             }
         }
 

--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -156,7 +156,7 @@ namespace LootLocker
             LootLocker.LootLockerEnums.LootLockerCallerRole callerRole = LootLocker.LootLockerEnums.LootLockerCallerRole.User)
         {
 #if UNITY_EDITOR
-            LootLockerLogger.EditorMessage("Caller Type: " + callerRole);
+            LootLockerLogger.EditorMessage("Caller Type: " + callerRole, LootLockerLogger.LogLevel.Verbose);
 #endif
 
             Dictionary<string, string> headers = new Dictionary<string, string>();
@@ -187,7 +187,7 @@ namespace LootLocker
             if (LootLockerConfig.current.domainKey.ToString().Length == 0)
             {
 #if UNITY_EDITOR
-                LootLockerLogger.EditorMessage("LootLocker domain key must be set in settings", true);
+                LootLockerLogger.EditorMessage("LootLocker domain key must be set in settings", LootLockerLogger.LogLevel.Error);
 #endif
                 onComplete?.Invoke(LootLockerResponseFactory.Error<LootLockerResponse>("LootLocker domain key must be set in settings"));
 
@@ -261,7 +261,7 @@ namespace LootLocker
 
             if (this.payload != null && isNonPayloadMethod)
             {
-                LootLockerLogger.EditorMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
+                LootLockerLogger.EditorMessage("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint, LootLockerLogger.LogLevel.Warning);
             }
         }
 
@@ -283,7 +283,7 @@ namespace LootLocker
             this.form = null;
             if (this.payload != null && isNonPayloadMethod)
             {
-                LootLockerLogger.EditorMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
+                LootLockerLogger.EditorMessage("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint, LootLockerLogger.LogLevel.Warning);
             }
         }
 
@@ -305,7 +305,7 @@ namespace LootLocker
             this.form = null;
             if (!string.IsNullOrEmpty(jsonPayload) && isNonPayloadMethod)
             {
-                LootLockerLogger.EditorMessage("WARNING: Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint);
+                LootLockerLogger.EditorMessage("Payloads should not be sent in GET, HEAD, OPTIONS, requests. Attempted to send a payload to: " + this.httpMethod.ToString() + " " + this.endpoint, LootLockerLogger.LogLevel.Warning);
             }
         }
 

--- a/Runtime/Game/LootLockerGameServerAPI.cs
+++ b/Runtime/Game/LootLockerGameServerAPI.cs
@@ -45,7 +45,7 @@ namespace LootLocker
                 }
                 case Platforms.AppleSignIn:
                 {
-                    LootLockerLogger.EditorMessage($"Token has expired, please refresh it", LootLockerLogger.LogLevel.Warning);
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)($"Token has expired, please refresh it");
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -58,7 +58,7 @@ namespace LootLocker
                 case Platforms.NintendoSwitch:
                 case Platforms.Steam:
                 {
-                    LootLockerLogger.EditorMessage($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}", LootLockerLogger.LogLevel.Warning);
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}");
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -82,7 +82,7 @@ namespace LootLocker
                 case Platforms.None:
                 default:
                 {
-                    LootLockerLogger.EditorMessage($"Platform {CurrentPlatform.GetFriendlyString()} not supported", LootLockerLogger.LogLevel.Error);
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)($"Platform {CurrentPlatform.GetFriendlyString()} not supported");
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -109,7 +109,7 @@ namespace LootLocker
                 }
                 else
                 {
-                    LootLockerLogger.EditorMessage("Session refresh failed", LootLockerLogger.LogLevel.Error);
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Session refresh failed");
                     LootLockerResponse res = new LootLockerResponse();
                     res.statusCode = 401;
                     res.Error = "Token Expired";
@@ -119,7 +119,7 @@ namespace LootLocker
             }
             else
             {
-                LootLockerLogger.EditorMessage("Session refresh failed", LootLockerLogger.LogLevel.Error);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Session refresh failed");
                 LootLockerResponse res = new LootLockerResponse();
                 res.statusCode = 401;
                 res.Error = "Token Expired";

--- a/Runtime/Game/LootLockerGameServerAPI.cs
+++ b/Runtime/Game/LootLockerGameServerAPI.cs
@@ -109,7 +109,7 @@ namespace LootLocker
                 }
                 else
                 {
-                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Session refresh failed");
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Info)("Session refresh failed");
                     LootLockerResponse res = new LootLockerResponse();
                     res.statusCode = 401;
                     res.Error = "Token Expired";
@@ -119,7 +119,7 @@ namespace LootLocker
             }
             else
             {
-                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Session refresh failed");
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Info)("Session refresh failed");
                 LootLockerResponse res = new LootLockerResponse();
                 res.statusCode = 401;
                 res.Error = "Token Expired";

--- a/Runtime/Game/LootLockerGameServerAPI.cs
+++ b/Runtime/Game/LootLockerGameServerAPI.cs
@@ -45,7 +45,7 @@ namespace LootLocker
                 }
                 case Platforms.AppleSignIn:
                 {
-                    LootLockerSDKManager.DebugMessage($"Token has expired, please refresh it", true);
+                    LootLockerLogger.EditorMessage($"Token has expired, please refresh it", true);
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -58,7 +58,7 @@ namespace LootLocker
                 case Platforms.NintendoSwitch:
                 case Platforms.Steam:
                 {
-                    LootLockerSDKManager.DebugMessage($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}", true);
+                    LootLockerLogger.EditorMessage($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}", true);
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -82,7 +82,7 @@ namespace LootLocker
                 case Platforms.None:
                 default:
                 {
-                    LootLockerSDKManager.DebugMessage($"Platform {CurrentPlatform.GetFriendlyString()} not supported", true);
+                    LootLockerLogger.EditorMessage($"Platform {CurrentPlatform.GetFriendlyString()} not supported", true);
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -109,7 +109,7 @@ namespace LootLocker
                 }
                 else
                 {
-                    LootLockerSDKManager.DebugMessage("Session refresh failed", true);
+                    LootLockerLogger.EditorMessage("Session refresh failed", true);
                     LootLockerResponse res = new LootLockerResponse();
                     res.statusCode = 401;
                     res.Error = "Token Expired";
@@ -119,7 +119,7 @@ namespace LootLocker
             }
             else
             {
-                LootLockerSDKManager.DebugMessage("Session refresh failed", true);
+                LootLockerLogger.EditorMessage("Session refresh failed", true);
                 LootLockerResponse res = new LootLockerResponse();
                 res.statusCode = 401;
                 res.Error = "Token Expired";

--- a/Runtime/Game/LootLockerGameServerAPI.cs
+++ b/Runtime/Game/LootLockerGameServerAPI.cs
@@ -45,7 +45,7 @@ namespace LootLocker
                 }
                 case Platforms.AppleSignIn:
                 {
-                    LootLockerLogger.EditorMessage($"Token has expired, please refresh it", true);
+                    LootLockerLogger.EditorMessage($"Token has expired, please refresh it", LootLockerLogger.LogLevel.Warning);
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -58,7 +58,7 @@ namespace LootLocker
                 case Platforms.NintendoSwitch:
                 case Platforms.Steam:
                 {
-                    LootLockerLogger.EditorMessage($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}", true);
+                    LootLockerLogger.EditorMessage($"Token has expired and token refresh is not supported for {CurrentPlatform.GetFriendlyString()}", LootLockerLogger.LogLevel.Warning);
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -82,7 +82,7 @@ namespace LootLocker
                 case Platforms.None:
                 default:
                 {
-                    LootLockerLogger.EditorMessage($"Platform {CurrentPlatform.GetFriendlyString()} not supported", true);
+                    LootLockerLogger.EditorMessage($"Platform {CurrentPlatform.GetFriendlyString()} not supported", LootLockerLogger.LogLevel.Error);
                     LootLockerResponse res = new LootLockerResponse
                     {
                         statusCode = 401,
@@ -109,7 +109,7 @@ namespace LootLocker
                 }
                 else
                 {
-                    LootLockerLogger.EditorMessage("Session refresh failed", true);
+                    LootLockerLogger.EditorMessage("Session refresh failed", LootLockerLogger.LogLevel.Error);
                     LootLockerResponse res = new LootLockerResponse();
                     res.statusCode = 401;
                     res.Error = "Token Expired";
@@ -119,7 +119,7 @@ namespace LootLocker
             }
             else
             {
-                LootLockerLogger.EditorMessage("Session refresh failed", true);
+                LootLockerLogger.EditorMessage("Session refresh failed", LootLockerLogger.LogLevel.Error);
                 LootLockerResponse res = new LootLockerResponse();
                 res.statusCode = 401;
                 res.Error = "Token Expired";

--- a/Runtime/Game/LootLockerLogger.cs
+++ b/Runtime/Game/LootLockerLogger.cs
@@ -1,49 +1,129 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace LootLocker
 {
     public class LootLockerLogger
     {
+        public enum LogLevel
+        {
+            Verbose
+            , Info
+            , Warning
+            , Error
+        }
+
         /// <summary>
-        /// LootLocker Debug-messages, only visible in the Unity Editor.
+        /// LootLocker Log messages, only visible in the Unity Editor.
         /// </summary>
         /// <param name="message">A message as a string</param>
-        /// <param name="IsError">Is this an error or not?</param>
-        public static void EditorMessage(string message, bool IsError = false)
+        /// <param name="logLevel">What level should this be logged as</param>
+        public static void EditorMessage(string message, LogLevel logLevel = LogLevel.Info)
         {
 #if UNITY_EDITOR
-            if (LootLockerConfig.current == null)
+            if (!ShouldLog(logLevel))
             {
-                if (IsError)
-                    Debug.LogError(message);
-                else
-                    Debug.Log(message);
                 return;
             }
 
-            if (LootLockerConfig.current != null &&
-                LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.All)
+            AdjustLogLevelToSettings(ref logLevel);
+
+            switch (logLevel)
             {
-                if (IsError)
+                case LogLevel.Error:
                     Debug.LogError(message);
-                else
+                    break;
+                case LogLevel.Warning:
+                    Debug.LogWarning(message);
+                    break;
+                case LogLevel.Verbose:
+                case LogLevel.Info:
+                default:
                     Debug.Log(message);
-            }
-            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.ErrorOnly)
-            {
-                if (IsError)
-                    Debug.LogError(message);
-            }
-            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.NormalOnly)
-            {
-                if (!IsError)
-                    Debug.LogError(message);
-            }
-            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.AllAsNormal)
-            {
-                Debug.Log(message);
+                    break;
             }
 #endif
+        }
+
+        private static bool ShouldLog(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Error:
+                {
+                    if (LootLockerConfig.current == null ||
+                        (new List<LootLockerConfig.DebugLevel>
+                        {
+                            LootLockerConfig.DebugLevel.All, 
+                            LootLockerConfig.DebugLevel.AllAsNormal,
+                            LootLockerConfig.DebugLevel.ErrorOnly
+                        }).Contains(LootLockerConfig.current.currentDebugLevel))
+                    {
+                        return true;
+                    }
+
+                    break;
+                }
+                case LogLevel.Warning:
+                {
+                    if (LootLockerConfig.current == null ||
+                        (new List<LootLockerConfig.DebugLevel>
+                        {
+                            LootLockerConfig.DebugLevel.All,
+                            LootLockerConfig.DebugLevel.AllAsNormal
+                        })
+                        .Contains(LootLockerConfig.current.currentDebugLevel))
+                    {
+                        return true;
+                    }
+
+                    break;
+                }
+                case LogLevel.Verbose:
+                {
+                    if (LootLockerConfig.current == null ||
+                        (new List<LootLockerConfig.DebugLevel>
+                        {
+                            LootLockerConfig.DebugLevel.All, 
+                            LootLockerConfig.DebugLevel.AllAsNormal
+                        })
+                        .Contains(LootLockerConfig.current.currentDebugLevel))
+                    {
+                        return true;
+                    }
+
+                    break;
+                }
+                case LogLevel.Info:
+                default:
+                {
+                    if (LootLockerConfig.current == null ||
+                        (new List<LootLockerConfig.DebugLevel>
+                        {
+                            LootLockerConfig.DebugLevel.All, 
+                            LootLockerConfig.DebugLevel.AllAsNormal,
+                            LootLockerConfig.DebugLevel.NormalOnly
+                        }).Contains(LootLockerConfig.current.currentDebugLevel))
+                    {
+                        return true;
+                    }
+
+                    break;
+                }
+            }
+
+            return false;
+        }
+
+        private static void AdjustLogLevelToSettings(ref LogLevel logLevel)
+        {
+            if (LootLockerConfig.current != null &&
+                LootLockerConfig.DebugLevel.AllAsNormal == LootLockerConfig.current.currentDebugLevel)
+            {
+                logLevel = LogLevel.Info;
+            }
         }
     }
 }

--- a/Runtime/Game/LootLockerLogger.cs
+++ b/Runtime/Game/LootLockerLogger.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+namespace LootLocker
+{
+    public class LootLockerLogger
+    {
+        /// <summary>
+        /// LootLocker Debug-messages, only visible in the Unity Editor.
+        /// </summary>
+        /// <param name="message">A message as a string</param>
+        /// <param name="IsError">Is this an error or not?</param>
+        public static void EditorMessage(string message, bool IsError = false)
+        {
+#if UNITY_EDITOR
+            if (LootLockerConfig.current == null)
+            {
+                if (IsError)
+                    Debug.LogError(message);
+                else
+                    Debug.Log(message);
+                return;
+            }
+
+            if (LootLockerConfig.current != null &&
+                LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.All)
+            {
+                if (IsError)
+                    Debug.LogError(message);
+                else
+                    Debug.Log(message);
+            }
+            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.ErrorOnly)
+            {
+                if (IsError)
+                    Debug.LogError(message);
+            }
+            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.NormalOnly)
+            {
+                if (!IsError)
+                    Debug.LogError(message);
+            }
+            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.AllAsNormal)
+            {
+                Debug.Log(message);
+            }
+#endif
+        }
+    }
+}

--- a/Runtime/Game/LootLockerLogger.cs
+++ b/Runtime/Game/LootLockerLogger.cs
@@ -16,16 +16,14 @@ namespace LootLocker
         }
 
         /// <summary>
-        /// LootLocker Log messages, only visible in the Unity Editor.
+        /// Get logger for the specified level. Use like: GetForLevel(LogLevel::Info)(message);
         /// </summary>
-        /// <param name="message">A message as a string</param>
         /// <param name="logLevel">What level should this be logged as</param>
-        public static void EditorMessage(string message, LogLevel logLevel = LogLevel.Info)
+        public static Action<string> GetForLogLevel(LogLevel logLevel = LogLevel.Info)
         {
-#if UNITY_EDITOR
             if (!ShouldLog(logLevel))
             {
-                return;
+                return ignored => { };
             }
 
             AdjustLogLevelToSettings(ref logLevel);
@@ -33,22 +31,19 @@ namespace LootLocker
             switch (logLevel)
             {
                 case LogLevel.Error:
-                    Debug.LogError(message);
-                    break;
+                    return Debug.LogError;
                 case LogLevel.Warning:
-                    Debug.LogWarning(message);
-                    break;
+                    return Debug.LogWarning;
                 case LogLevel.Verbose:
                 case LogLevel.Info:
                 default:
-                    Debug.Log(message);
-                    break;
+                    return Debug.Log;
             }
-#endif
         }
 
         private static bool ShouldLog(LogLevel logLevel)
         {
+#if UNITY_EDITOR
             switch (logLevel)
             {
                 case LogLevel.Error:
@@ -113,6 +108,7 @@ namespace LootLocker
                     break;
                 }
             }
+#endif
 
             return false;
         }

--- a/Runtime/Game/LootLockerLogger.cs.meta
+++ b/Runtime/Game/LootLockerLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 013fed298e3df304f8320a4ecdf1e009
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -77,7 +77,7 @@ namespace LootLocker.Requests
             }
             if (string.IsNullOrEmpty(LootLockerConfig.current.apiKey))
             {
-                DebugMessage("Key has not been set, Please login to sdk manager or set key manually and then try again");
+                DebugMessage("Key has not been set, Please login to sdk manager or set key manually and then try again", true);
                 return false;
             }
 
@@ -155,7 +155,7 @@ namespace LootLocker.Requests
             else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.NormalOnly)
             {
                 if (!IsError)
-                    Debug.LogError(message);
+                    Debug.Log(message);
             }
 #endif
         }
@@ -1267,7 +1267,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                DebugMessage($"File error: {e.Message}");
+                DebugMessage($"File error: {e.Message}", true);
                 return;
             }
 
@@ -1319,7 +1319,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                DebugMessage($"File error: {e.Message}");
+                DebugMessage($"File error: {e.Message}", true);
                 return;
             }
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -155,7 +155,11 @@ namespace LootLocker.Requests
             else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.NormalOnly)
             {
                 if (!IsError)
-                    Debug.Log(message);
+                    Debug.LogError(message);
+            }
+            else if(LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.AllAsNormal)
+            {
+                Debug.Log(message);
             }
 #endif
         }

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
-using LootLocker.Requests;
-using LootLocker;
 using System.Security.Cryptography;
 using System.Text;
 using Newtonsoft.Json;
@@ -29,7 +26,7 @@ namespace LootLocker.Requests
         static bool initialized;
         static bool Init()
         {
-            DebugMessage("SDK is Intializing");
+            LootLockerLogger.EditorMessage("SDK is Intializing");
             LootLockerServerManager.CheckInit();
             return LoadConfig();
         }
@@ -44,7 +41,7 @@ namespace LootLocker.Requests
         /// <returns>True if initialized successfully, false otherwise</returns>
         public static bool Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)
         {
-            DebugMessage("SDK is Intializing");
+            LootLockerLogger.EditorMessage("SDK is Intializing");
             LootLockerServerManager.CheckInit();
             return LootLockerConfig.CreateNewSettings(apiKey, gameVersion, onDevelopmentMode, domainKey);
         }
@@ -61,7 +58,7 @@ namespace LootLocker.Requests
         [Obsolete("DEPRECATED: Initializing with a platform is deprecated, use Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)")]
         public static bool Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)
         {
-            DebugMessage("SDK is Intializing");
+            LootLockerLogger.EditorMessage("SDK is Intializing");
             LootLockerServerManager.CheckInit();
             initialized = LootLockerConfig.CreateNewSettings(apiKey, gameVersion, onDevelopmentMode, domainKey, platform);
             return initialized;
@@ -72,12 +69,12 @@ namespace LootLocker.Requests
             initialized = false;
             if (LootLockerConfig.current == null)
             {
-                DebugMessage("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)", true);
+                LootLockerLogger.EditorMessage("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)", true);
                 return false;
             }
             if (string.IsNullOrEmpty(LootLockerConfig.current.apiKey))
             {
-                DebugMessage("Key has not been set, Please login to sdk manager or set key manually and then try again", true);
+                LootLockerLogger.EditorMessage("Key has not been set, Please login to sdk manager or set key manually and then try again", true);
                 return false;
             }
 
@@ -116,52 +113,11 @@ namespace LootLocker.Requests
 
             if (!skipSessionCheck && !CheckActiveSession())
             {
-                DebugMessage("You cannot call this method before an active LootLocker session is started", true);
+                LootLockerLogger.EditorMessage("You cannot call this method before an active LootLocker session is started", true);
                 return false;
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// LootLocker Debug-messages, only visible in the Unity Editor.
-        /// </summary>
-        /// <param name="message">A message as a string</param>
-        /// <param name="IsError">Is this an error or not?</param>
-        public static void DebugMessage(string message, bool IsError = false)
-        {
-#if     UNITY_EDITOR
-            if (LootLockerConfig.current == null)
-            {
-                if (IsError)
-                    Debug.LogError(message);
-                else
-                    Debug.Log(message);
-                return;
-            }
-
-            if (LootLockerConfig.current != null && LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.All)
-            {
-                if (IsError)
-                    Debug.LogError(message);
-                else
-                    Debug.Log(message);
-            }
-            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.ErrorOnly)
-            {
-                if (IsError)
-                    Debug.LogError(message);
-            }
-            else if (LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.NormalOnly)
-            {
-                if (!IsError)
-                    Debug.LogError(message);
-            }
-            else if(LootLockerConfig.current.currentDebugLevel == LootLockerConfig.DebugLevel.AllAsNormal)
-            {
-                Debug.Log(message);
-            }
-#endif
         }
 
         #endregion
@@ -1271,7 +1227,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                DebugMessage($"File error: {e.Message}", true);
+                LootLockerLogger.EditorMessage($"File error: {e.Message}", true);
                 return;
             }
 
@@ -1323,7 +1279,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                DebugMessage($"File error: {e.Message}", true);
+                LootLockerLogger.EditorMessage($"File error: {e.Message}", true);
                 return;
             }
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -26,7 +26,7 @@ namespace LootLocker.Requests
         static bool initialized;
         static bool Init()
         {
-            LootLockerLogger.EditorMessage("SDK is Intializing");
+            LootLockerLogger.GetForLogLevel()("SDK is Intializing");
             LootLockerServerManager.CheckInit();
             return LoadConfig();
         }
@@ -41,7 +41,7 @@ namespace LootLocker.Requests
         /// <returns>True if initialized successfully, false otherwise</returns>
         public static bool Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)
         {
-            LootLockerLogger.EditorMessage("SDK is Intializing");
+            LootLockerLogger.GetForLogLevel()("SDK is Intializing");
             LootLockerServerManager.CheckInit();
             return LootLockerConfig.CreateNewSettings(apiKey, gameVersion, onDevelopmentMode, domainKey);
         }
@@ -58,7 +58,7 @@ namespace LootLocker.Requests
         [Obsolete("DEPRECATED: Initializing with a platform is deprecated, use Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)")]
         public static bool Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)
         {
-            LootLockerLogger.EditorMessage("SDK is Intializing");
+            LootLockerLogger.GetForLogLevel()("SDK is Intializing");
             LootLockerServerManager.CheckInit();
             initialized = LootLockerConfig.CreateNewSettings(apiKey, gameVersion, onDevelopmentMode, domainKey, platform);
             return initialized;
@@ -69,12 +69,12 @@ namespace LootLocker.Requests
             initialized = false;
             if (LootLockerConfig.current == null)
             {
-                LootLockerLogger.EditorMessage("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)", LootLockerLogger.LogLevel.Error);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)");
                 return false;
             }
             if (string.IsNullOrEmpty(LootLockerConfig.current.apiKey))
             {
-                LootLockerLogger.EditorMessage("API Key has not been set, set it in project settings or manually calling Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)", LootLockerLogger.LogLevel.Error);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("API Key has not been set, set it in project settings or manually calling Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)");
                 return false;
             }
 
@@ -113,7 +113,7 @@ namespace LootLocker.Requests
 
             if (!skipSessionCheck && !CheckActiveSession())
             {
-                LootLockerLogger.EditorMessage("You cannot call this method before an active LootLocker session is started", LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("You cannot call this method before an active LootLocker session is started");
                 return false;
             }
 
@@ -1227,7 +1227,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                LootLockerLogger.EditorMessage($"File error: {e.Message}", LootLockerLogger.LogLevel.Error);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)($"File error: {e.Message}");
                 return;
             }
 
@@ -1279,7 +1279,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                LootLockerLogger.EditorMessage($"File error: {e.Message}", LootLockerLogger.LogLevel.Error);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)($"File error: {e.Message}");
                 return;
             }
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -69,12 +69,12 @@ namespace LootLocker.Requests
             initialized = false;
             if (LootLockerConfig.current == null)
             {
-                LootLockerLogger.EditorMessage("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)", true);
+                LootLockerLogger.EditorMessage("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)", LootLockerLogger.LogLevel.Error);
                 return false;
             }
             if (string.IsNullOrEmpty(LootLockerConfig.current.apiKey))
             {
-                LootLockerLogger.EditorMessage("Key has not been set, Please login to sdk manager or set key manually and then try again", true);
+                LootLockerLogger.EditorMessage("API Key has not been set, set it in project settings or manually calling Init(string apiKey, string gameVersion, bool onDevelopmentMode, string domainKey)", LootLockerLogger.LogLevel.Error);
                 return false;
             }
 
@@ -113,7 +113,7 @@ namespace LootLocker.Requests
 
             if (!skipSessionCheck && !CheckActiveSession())
             {
-                LootLockerLogger.EditorMessage("You cannot call this method before an active LootLocker session is started", true);
+                LootLockerLogger.EditorMessage("You cannot call this method before an active LootLocker session is started", LootLockerLogger.LogLevel.Warning);
                 return false;
             }
 
@@ -1227,7 +1227,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                LootLockerLogger.EditorMessage($"File error: {e.Message}", true);
+                LootLockerLogger.EditorMessage($"File error: {e.Message}", LootLockerLogger.LogLevel.Error);
                 return;
             }
 
@@ -1279,7 +1279,7 @@ namespace LootLocker.Requests
             }
             catch (Exception e)
             {
-                LootLockerLogger.EditorMessage($"File error: {e.Message}", true);
+                LootLockerLogger.EditorMessage($"File error: {e.Message}", LootLockerLogger.LogLevel.Error);
                 return;
             }
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -72,7 +72,7 @@ namespace LootLocker.Requests
             initialized = false;
             if (LootLockerConfig.current == null)
             {
-                Debug.LogError("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)");
+                DebugMessage("SDK could not find settings, please contact support \n You can also set config manually by calling Init(string apiKey, string gameVersion, platformType platform, bool onDevelopmentMode, string domainKey)", true);
                 return false;
             }
             if (string.IsNullOrEmpty(LootLockerConfig.current.apiKey))
@@ -116,7 +116,7 @@ namespace LootLocker.Requests
 
             if (!skipSessionCheck && !CheckActiveSession())
             {
-                Debug.LogError("You cannot call this method before an active LootLocker session is started");
+                DebugMessage("You cannot call this method before an active LootLocker session is started", true);
                 return false;
             }
 

--- a/Runtime/Game/LootLockerValidation.cs
+++ b/Runtime/Game/LootLockerValidation.cs
@@ -47,13 +47,13 @@ namespace LootLocker
             catch (RegexMatchTimeoutException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerLogger.EditorMessage("Regex exception: " + e, LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Regex exception: " + e);
                 return false;
             }
             catch (ArgumentException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerLogger.EditorMessage("Argument exception: " + e, LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Argument exception: " + e);
                 return false;
             }
 
@@ -72,7 +72,7 @@ namespace LootLocker
             catch (RegexMatchTimeoutException e)
             {
                 error = "The email you entered was invalid.";
-                LootLockerLogger.EditorMessage("Regex exception: " + e, LootLockerLogger.LogLevel.Warning);
+                LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Regex exception: " + e);
                 return false;
             }
         }

--- a/Runtime/Game/LootLockerValidation.cs
+++ b/Runtime/Game/LootLockerValidation.cs
@@ -90,7 +90,6 @@ namespace LootLocker
             bool hasLength = lengthCheck.IsMatch(password);
 
             bool isValidPassword = hasNumber && hasUppercase && hasLength;
-            //Debug.Log("Is password valid? = " + isValidPassword);
 
             if (!isValidPassword)
             {

--- a/Runtime/Game/LootLockerValidation.cs
+++ b/Runtime/Game/LootLockerValidation.cs
@@ -47,13 +47,13 @@ namespace LootLocker
             catch (RegexMatchTimeoutException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerLogger.EditorMessage("Regex exception: " + e, true);
+                LootLockerLogger.EditorMessage("Regex exception: " + e, LootLockerLogger.LogLevel.Warning);
                 return false;
             }
             catch (ArgumentException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerLogger.EditorMessage("Argument exception: " + e, true);
+                LootLockerLogger.EditorMessage("Argument exception: " + e, LootLockerLogger.LogLevel.Warning);
                 return false;
             }
 
@@ -72,7 +72,7 @@ namespace LootLocker
             catch (RegexMatchTimeoutException e)
             {
                 error = "The email you entered was invalid.";
-                LootLockerLogger.EditorMessage("Regex exception: " + e, true);
+                LootLockerLogger.EditorMessage("Regex exception: " + e, LootLockerLogger.LogLevel.Warning);
                 return false;
             }
         }

--- a/Runtime/Game/LootLockerValidation.cs
+++ b/Runtime/Game/LootLockerValidation.cs
@@ -47,13 +47,13 @@ namespace LootLocker
             catch (RegexMatchTimeoutException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerSDKManager.DebugMessage("Regex exception: " + e, true);
+                LootLockerLogger.EditorMessage("Regex exception: " + e, true);
                 return false;
             }
             catch (ArgumentException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerSDKManager.DebugMessage("Argument exception: " + e, true);
+                LootLockerLogger.EditorMessage("Argument exception: " + e, true);
                 return false;
             }
 
@@ -72,7 +72,7 @@ namespace LootLocker
             catch (RegexMatchTimeoutException e)
             {
                 error = "The email you entered was invalid.";
-                LootLockerSDKManager.DebugMessage("Regex exception: " + e, true);
+                LootLockerLogger.EditorMessage("Regex exception: " + e, true);
                 return false;
             }
         }

--- a/Runtime/Game/LootLockerValidation.cs
+++ b/Runtime/Game/LootLockerValidation.cs
@@ -53,7 +53,7 @@ namespace LootLocker
             catch (ArgumentException e)
             {
                 error = "An error has occurred. Please try again.";
-                LootLockerSDKManager.DebugMessage("Argument exception: " + e);
+                LootLockerSDKManager.DebugMessage("Argument exception: " + e, true);
                 return false;
             }
 

--- a/Runtime/Game/Requests/CrashesRequest.cs
+++ b/Runtime/Game/Requests/CrashesRequest.cs
@@ -46,7 +46,7 @@ namespace LootLocker
                 LootLockerResponse response = new LootLockerResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
                 {
-                    LootLockerLogger.EditorMessage(serverResponse.text, LootLockerLogger.LogLevel.Verbose);
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)(serverResponse.text);
                     response = JsonConvert.DeserializeObject<LootLockerResponse>(serverResponse.text);
                     onComplete?.Invoke(response);
                 }

--- a/Runtime/Game/Requests/CrashesRequest.cs
+++ b/Runtime/Game/Requests/CrashesRequest.cs
@@ -46,7 +46,7 @@ namespace LootLocker
                 LootLockerResponse response = new LootLockerResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
                 {
-                    LootLockerLogger.EditorMessage(serverResponse.text);
+                    LootLockerLogger.EditorMessage(serverResponse.text, LootLockerLogger.LogLevel.Verbose);
                     response = JsonConvert.DeserializeObject<LootLockerResponse>(serverResponse.text);
                     onComplete?.Invoke(response);
                 }

--- a/Runtime/Game/Requests/CrashesRequest.cs
+++ b/Runtime/Game/Requests/CrashesRequest.cs
@@ -46,7 +46,7 @@ namespace LootLocker
                 LootLockerResponse response = new LootLockerResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
                 {
-                    LootLockerSDKManager.DebugMessage(serverResponse.text);
+                    LootLockerLogger.EditorMessage(serverResponse.text);
                     response = JsonConvert.DeserializeObject<LootLockerResponse>(serverResponse.text);
                     onComplete?.Invoke(response);
                 }

--- a/Runtime/Game/Requests/WhiteLabelRequest.cs
+++ b/Runtime/Game/Requests/WhiteLabelRequest.cs
@@ -1,11 +1,6 @@
 using Newtonsoft.Json;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
 using LootLocker.Requests;
-using LootLocker.LootLockerEnums;
 using Newtonsoft.Json.Serialization;
 
 namespace LootLocker.Requests

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -154,7 +154,7 @@ namespace LootLocker
         public string userUrl = "https://api.lootlocker.io/game";
         [HideInInspector]
         public string baseUrl = "https://api.lootlocker.io";
-        public enum DebugLevel { All, ErrorOnly, NormalOnly, Off }
+        public enum DebugLevel { All, ErrorOnly, NormalOnly, Off , AllAsNormal}
         public DebugLevel currentDebugLevel = DebugLevel.All;
         public bool allowTokenRefresh = true;
 


### PR DESCRIPTION
2 things fixed
- The status codes from the responses where never checked, so no errors were thrown on things like 404, 500 etc.
- The log-error levels were all wrong, causing errors to not being thrown as errors.
Before (Easily missed):
![image](https://user-images.githubusercontent.com/97440747/216049699-57b70408-4cfc-4ef3-b0f7-139070d11ce4.png)
After:
![image](https://user-images.githubusercontent.com/97440747/216048645-05b1ead0-d5a9-4874-8065-a58874226677.png)