### PR TITLE
Switch out external newtonsoft to Unity.Plastic

### DIFF
--- a/Runtime/Client/GetRequests.cs
+++ b/Runtime/Client/GetRequests.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using Newtonsoft.Json;
+﻿using System.Collections.Generic;
 
 namespace LootLocker.Requests
 {

--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -2,12 +2,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
-using Newtonsoft.Json;
+//using Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json;
 using System;
 using System.Text;
 using System.Net;
 using LootLocker.Requests;
-using Newtonsoft.Json.Linq;
+//using Newtonsoft.Json.Linq;
+using Unity.Plastic.Newtonsoft.Json.Linq;
 
 namespace LootLocker.LootLockerEnums
 {
@@ -289,7 +291,7 @@ namespace LootLocker
                     }
                     else
                     {
-                        string json = (request.payload != null && request.payload.Count > 0) ? JsonConvert.SerializeObject(request.payload) : request.jsonPayload;
+                        string json = (request.payload != null && request.payload.Count > 0) ? LootLockerJson.SerializeObject(request.payload) : request.jsonPayload;
 #if UNITY_EDITOR
                         LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)("REQUEST BODY = " + ObfuscateJsonStringForLogging(json));
 #endif
@@ -431,7 +433,7 @@ namespace LootLocker
                 }
             }
 
-            return JsonConvert.SerializeObject(jsonObject);
+            return LootLockerJson.SerializeObject(jsonObject);
         }
 
         string BuildURL(string endpoint, Dictionary<string, string> queryParams = null)

--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System;
-using Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json;
 using LootLocker.LootLockerEnums;
-using LootLocker.Requests;
-using Newtonsoft.Json.Serialization;
+using Unity.Plastic.Newtonsoft.Json.Serialization;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -29,6 +28,19 @@ namespace LootLocker
             ContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() },
             Formatting = Formatting.None
         };
+    }
+
+    public static class LootLockerJson
+    {
+        public static string SerializeObject(object obj, JsonSerializerSettings settings = null)
+        {
+            return JsonConvert.SerializeObject(obj, settings ?? LootLockerJsonSettings.Default);
+        }
+
+        public static T DeserializeObject<T>(string json, JsonSerializerSettings settings = null)
+        {
+            return JsonConvert.DeserializeObject<T>(json, settings ?? LootLockerJsonSettings.Default);
+        }
     }
 
     [System.Serializable]
@@ -102,7 +114,7 @@ namespace LootLocker
                 return new T() { success = false, Error = serverResponse.Error, statusCode = serverResponse.statusCode };
             }
 
-            var response = JsonConvert.DeserializeObject<T>(serverResponse.text, settings ?? LootLockerJsonSettings.Default) ?? new T();
+            var response = LootLockerJson.DeserializeObject<T>(serverResponse.text, settings ?? LootLockerJsonSettings.Default) ?? new T();
 
             response.text = serverResponse.text;
             response.success = serverResponse.success;

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -4,7 +4,6 @@ using System.IO;
 using UnityEngine;
 using System.Security.Cryptography;
 using System.Text;
-using Newtonsoft.Json;
 using LootLocker.LootLockerEnums;
 using static LootLocker.LootLockerConfig;
 using System.Linq;
@@ -1776,7 +1775,7 @@ namespace LootLocker.Requests
 
             var endpoint = string.Format(LootLockerEndPoints.addPointsToPlayerProgression.endPoint, progressionKey);
 
-            var body = JsonConvert.SerializeObject(new { amount });  
+            var body = LootLockerJson.SerializeObject(new { amount });  
 
             LootLockerServerRequest.CallAPI(endpoint, LootLockerHTTPMethod.POST, body, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
@@ -1797,7 +1796,7 @@ namespace LootLocker.Requests
 
             var endpoint = string.Format(LootLockerEndPoints.subtractPointsFromPlayerProgression.endPoint, progressionKey);
             
-            var body = JsonConvert.SerializeObject(new { amount });
+            var body = LootLockerJson.SerializeObject(new { amount });
 
             LootLockerServerRequest.CallAPI(endpoint, LootLockerHTTPMethod.POST, body, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
@@ -2223,7 +2222,7 @@ namespace LootLocker.Requests
 
             var endpoint = string.Format(LootLockerEndPoints.addPointsToCharacterProgression.endPoint, characterId, progressionKey);
 
-            var body = JsonConvert.SerializeObject(new { amount });  
+            var body = LootLockerJson.SerializeObject(new { amount });  
 
             LootLockerServerRequest.CallAPI(endpoint, LootLockerHTTPMethod.POST, body, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
@@ -2245,7 +2244,7 @@ namespace LootLocker.Requests
 
             var endpoint = string.Format(LootLockerEndPoints.subtractPointsFromCharacterProgression.endPoint, characterId, progressionKey);
             
-            var body = JsonConvert.SerializeObject(new { amount });
+            var body = LootLockerJson.SerializeObject(new { amount });
 
             LootLockerServerRequest.CallAPI(endpoint, LootLockerHTTPMethod.POST, body, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
@@ -3246,7 +3245,7 @@ namespace LootLocker.Requests
                 return;
             }
 
-            string source = JsonConvert.SerializeObject(finishingPayload) + startingMissionSignature + playerId;
+            string source = LootLockerJson.SerializeObject(finishingPayload) + startingMissionSignature + playerId;
             string hash;
             using (SHA1 sha1Hash = SHA1.Create())
             {
@@ -3280,7 +3279,7 @@ namespace LootLocker.Requests
                 onComplete?.Invoke(LootLockerResponseFactory.SDKNotInitializedError<LootLockerFinishMissionResponse>());
                 return;
             }
-            string source = JsonConvert.SerializeObject(finishingPayload) + startingMissionSignature + playerId;
+            string source = LootLockerJson.SerializeObject(finishingPayload) + startingMissionSignature + playerId;
             string hash;
             using (SHA1 sha1Hash = SHA1.Create())
             {

--- a/Runtime/Game/Requests/AssetInstanceRequest.cs
+++ b/Runtime/Game/Requests/AssetInstanceRequest.cs
@@ -1,11 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
-using LootLocker.Requests;
-using Newtonsoft.Json;
+﻿using LootLocker.Requests;
 using System;
-using System.Linq;
 
 namespace LootLocker.Requests
 {
@@ -101,7 +95,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.getAKeyValuePairById;
 
@@ -118,7 +112,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.createKeyValuePair;
 
@@ -135,7 +129,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.updateOneOrMoreKeyValuePair;
 
@@ -152,7 +146,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.updateKeyValuePairById;
 

--- a/Runtime/Game/Requests/AssetRequest.cs
+++ b/Runtime/Game/Requests/AssetRequest.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿//using Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -335,11 +336,11 @@ namespace LootLocker
                 LootLockerAssetResponse realResponse = LootLockerResponse.Deserialize<LootLockerAssetResponse>(serverResponse);
                 LootLockerSingleAssetResponse newResponse = new LootLockerSingleAssetResponse();
 
-                string serializedAsset = JsonConvert.SerializeObject(realResponse.assets[0], Formatting.Indented);
+                string serializedAsset = LootLockerJson.SerializeObject(realResponse.assets[0], LootLockerJsonSettings.Indented);
 
-                newResponse.asset = JsonConvert.DeserializeObject<LootLockerCommonAsset>(serializedAsset);
+                newResponse.asset = LootLockerJson.DeserializeObject<LootLockerCommonAsset>(serializedAsset);
 
-                string singleAssetResponse = JsonConvert.SerializeObject(newResponse, Formatting.Indented);
+                string singleAssetResponse = LootLockerJson.SerializeObject(newResponse, LootLockerJsonSettings.Indented);
                 newResponse.text = singleAssetResponse;
                 newResponse.SetResponseInfo(serverResponse);
 

--- a/Runtime/Game/Requests/CharacterRequest.cs
+++ b/Runtime/Game/Requests/CharacterRequest.cs
@@ -1,10 +1,5 @@
-﻿using LootLocker;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using System;
 using LootLocker.Requests;
-using Newtonsoft.Json;
 using System.Linq;
 
 
@@ -143,7 +138,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             string getVariable = endPoint.endPoint;
 
@@ -185,7 +180,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.updateCharacter;
 
@@ -202,7 +197,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.equipIDAssetToDefaultCharacter;
 
@@ -219,7 +214,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.equipGlobalAssetToDefaultCharacter;
 
@@ -236,7 +231,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.equipIDAssetToCharacter;
 
@@ -253,7 +248,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.equipGlobalAssetToCharacter;
 

--- a/Runtime/Game/Requests/CollectableRequest.cs
+++ b/Runtime/Game/Requests/CollectableRequest.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
-using LootLocker.Requests;
-using Newtonsoft.Json;
+﻿using LootLocker.Requests;
 using System;
 using System.Linq;
 using UnityEngine.UI;
@@ -106,7 +101,7 @@ namespace LootLocker
             {
                 LootLockerGetCollectablesResponse response = new LootLockerGetCollectablesResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
-                    response = JsonConvert.DeserializeObject<LootLockerGetCollectablesResponse>(serverResponse.text);
+                    response = LootLockerJson.DeserializeObject<LootLockerGetCollectablesResponse>(serverResponse.text);
 
                 response.text = serverResponse.text;
                 response.success = serverResponse.success;
@@ -125,7 +120,7 @@ namespace LootLocker
             {
                 LootLockerGettingCollectablesResponse response = new LootLockerGettingCollectablesResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
-                    response = JsonConvert.DeserializeObject<LootLockerGettingCollectablesResponse>(serverResponse.text);
+                    response = LootLockerJson.DeserializeObject<LootLockerGettingCollectablesResponse>(serverResponse.text);
 
                 response.text = serverResponse.text;
                 response.success = serverResponse.success;
@@ -143,7 +138,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.collectingAnItem;
 
@@ -152,7 +147,7 @@ namespace LootLocker
                 LootLockerCollectItemResponse response = new LootLockerCollectItemResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
                 {
-                    response = JsonConvert.DeserializeObject<LootLockerCollectItemResponse>(serverResponse.text);
+                    response = LootLockerJson.DeserializeObject<LootLockerCollectItemResponse>(serverResponse.text);
                     string[] collectableStrings = data.slug.Split('.');
 
                     string collectable = collectableStrings[0];
@@ -181,7 +176,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.collectingAnItem;
 
@@ -190,7 +185,7 @@ namespace LootLocker
                 LootLockerCollectingAnItemResponse response = new LootLockerCollectingAnItemResponse();
                 if (string.IsNullOrEmpty(serverResponse.Error))
                 {
-                    response = JsonConvert.DeserializeObject<LootLockerCollectingAnItemResponse>(serverResponse.text);
+                    response = LootLockerJson.DeserializeObject<LootLockerCollectingAnItemResponse>(serverResponse.text);
                     string[] collectableStrings = data.slug.Split('.');
 
                     string collectable = collectableStrings[0];

--- a/Runtime/Game/Requests/CrashesRequest.cs
+++ b/Runtime/Game/Requests/CrashesRequest.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿//using Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -47,7 +48,7 @@ namespace LootLocker
                 if (string.IsNullOrEmpty(serverResponse.Error))
                 {
                     LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Verbose)(serverResponse.text);
-                    response = JsonConvert.DeserializeObject<LootLockerResponse>(serverResponse.text);
+                    response = LootLockerJson.DeserializeObject<LootLockerResponse>(serverResponse.text);
                     onComplete?.Invoke(response);
                 }
                 else

--- a/Runtime/Game/Requests/DropTableRequest.cs
+++ b/Runtime/Game/Requests/DropTableRequest.cs
@@ -1,9 +1,5 @@
 using LootLocker.Requests;
-using Newtonsoft.Json;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace LootLocker.Requests
 {
@@ -68,7 +64,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             string endPoint = string.Format(requestEndPoint.endPoint, tableInstanceId);
 

--- a/Runtime/Game/Requests/EventRequest.cs
+++ b/Runtime/Game/Requests/EventRequest.cs
@@ -1,10 +1,5 @@
 ﻿using LootLocker.Requests;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
-using Newtonsoft.Json;
 
 namespace LootLocker.Requests
 {
@@ -154,7 +149,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.finishingEvent;
 

--- a/Runtime/Game/Requests/LeaderboardRequest.cs
+++ b/Runtime/Game/Requests/LeaderboardRequest.cs
@@ -1,11 +1,5 @@
-using Newtonsoft.Json;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
 using LootLocker.Requests;
-using LootLocker.LootLockerEnums;
 
 
 namespace LootLocker.Requests
@@ -151,7 +145,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             string endPoint = string.Format(requestEndPoint.endPoint, id);
 
@@ -200,7 +194,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             string endPoint = string.Format(requestEndPoint.endPoint, id);
 

--- a/Runtime/Game/Requests/LootLockerSessionRequest.cs
+++ b/Runtime/Game/Requests/LootLockerSessionRequest.cs
@@ -1,9 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
+﻿using System;
 using LootLocker.Requests;
 
 
@@ -232,7 +227,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
@@ -253,7 +248,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
@@ -274,7 +269,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
@@ -293,7 +288,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             GoogleSession(json, onComplete);
         }
 
@@ -305,7 +300,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             GoogleSession(json, onComplete);
         }
 
@@ -337,7 +332,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
@@ -357,7 +352,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             EpicSession(json, onComplete);
         }
 
@@ -369,7 +364,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             EpicSession(json, onComplete);
         }
 
@@ -397,7 +392,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
@@ -416,7 +411,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             AppleSession(json, onComplete);
         }
 
@@ -428,7 +423,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             AppleSession(json, onComplete);
         }
 
@@ -460,7 +455,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
 
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });

--- a/Runtime/Game/Requests/LootLockerVerifyRequest.cs
+++ b/Runtime/Game/Requests/LootLockerVerifyRequest.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using LootLocker.Requests;
 
 
@@ -43,7 +42,7 @@ namespace LootLocker
             	onComplete?.Invoke(LootLockerResponseFactory.InputUnserializableError<LootLockerVerifyResponse>());
             	return;
             }
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
             LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             EndPointClass endPoint = LootLockerEndPoints.playerVerification;
 

--- a/Runtime/Game/Requests/MapsRequest.cs
+++ b/Runtime/Game/Requests/MapsRequest.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 using LootLocker.Requests;
 using LootLocker;
 using System;
-using Newtonsoft.Json;
+//using Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json;
 
 namespace LootLocker.Requests
 {

--- a/Runtime/Game/Requests/MessagesRequest.cs
+++ b/Runtime/Game/Requests/MessagesRequest.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using LootLocker;
 using LootLocker.Requests;
-using Newtonsoft.Json;
+//using Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json;
 using System;
 
 namespace LootLocker.Requests

--- a/Runtime/Game/Requests/MissionsRequest.cs
+++ b/Runtime/Game/Requests/MissionsRequest.cs
@@ -1,9 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
+﻿using System;
 using LootLocker.Requests;
 
 
@@ -158,7 +153,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass requestEndPoint = LootLockerEndPoints.finishingMission;
 
@@ -175,7 +170,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass requestEndPoint = LootLockerEndPoints.finishingMission;
 

--- a/Runtime/Game/Requests/PersitentPlayerStorageRequest.cs
+++ b/Runtime/Game/Requests/PersitentPlayerStorageRequest.cs
@@ -1,9 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
+﻿using System.Collections.Generic;
 using LootLocker.Requests;
-using Newtonsoft.Json;
 using System;
 
 namespace LootLocker.Requests
@@ -68,7 +64,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.updateOrCreateKeyValue;
 

--- a/Runtime/Game/Requests/PlayerRequest.cs
+++ b/Runtime/Game/Requests/PlayerRequest.cs
@@ -1,6 +1,6 @@
-using Newtonsoft.Json;
 using System;
 using LootLocker.Requests;
+using Unity.Plastic.Newtonsoft.Json;
 
 namespace LootLocker.Requests
 {
@@ -300,7 +300,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             var endPoint = LootLockerEndPoints.submitXp;
 
@@ -426,7 +426,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             var endPoint = LootLockerEndPoints.setPlayerName;
 

--- a/Runtime/Game/Requests/PurchaseRequest.cs
+++ b/Runtime/Game/Requests/PurchaseRequest.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
-using LootLocker.Requests;
-using Newtonsoft.Json;
+﻿using LootLocker.Requests;
 using System;
 
 namespace LootLocker.Requests
@@ -56,7 +51,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.normalPurchaseCall;
 
@@ -71,7 +66,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.rentalPurchaseCall;
 
@@ -86,7 +81,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.iosPurchaseVerification;
 
@@ -101,7 +96,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.androidPurchaseVerification;
 

--- a/Runtime/Game/Requests/ReportRequets.cs
+++ b/Runtime/Game/Requests/ReportRequets.cs
@@ -1,11 +1,5 @@
-using Newtonsoft.Json;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
 using LootLocker.Requests;
-using LootLocker.LootLockerEnums;
 
 
 namespace LootLocker.Requests
@@ -153,7 +147,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             LootLockerServerRequest.CallAPI(requestEndPoint.endPoint, requestEndPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
@@ -167,7 +161,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             LootLockerServerRequest.CallAPI(requestEndPoint.endPoint, requestEndPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }

--- a/Runtime/Game/Requests/TriggerEventsRequest.cs
+++ b/Runtime/Game/Requests/TriggerEventsRequest.cs
@@ -1,5 +1,4 @@
 ﻿using LootLocker.Requests;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -106,7 +105,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.triggeringAnEvent;
 
@@ -122,7 +121,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.triggeringAnEvent;
 

--- a/Runtime/Game/Requests/UserGeneratedContentRequest.cs
+++ b/Runtime/Game/Requests/UserGeneratedContentRequest.cs
@@ -1,11 +1,6 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
-using UnityEngine;
-using LootLocker;
 using LootLocker.Requests;
-using LootLocker.LootLockerEnums;
 
 namespace LootLocker.LootLockerEnums
 {
@@ -141,7 +136,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             EndPointClass endPoint = LootLockerEndPoints.creatingAnAssetCandidate;
 
@@ -157,7 +152,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(data);
+            string json = LootLockerJson.SerializeObject(data);
 
             string endPoint = string.Format(requestEndPoint.endPoint, getRequests.getRequests[0]);
 

--- a/Runtime/Game/Requests/WhiteLabelRequest.cs
+++ b/Runtime/Game/Requests/WhiteLabelRequest.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using System;
 using LootLocker.Requests;
 
@@ -89,7 +88,7 @@ namespace LootLocker
             	return;
             }
             
-            string json = JsonConvert.SerializeObject(input);
+            string json = LootLockerJson.SerializeObject(input);
 
             LootLockerServerRequest.CallDomainAuthAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse, LootLockerJsonSettings.Indented); });
         }
@@ -104,7 +103,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = JsonConvert.SerializeObject(input);
+            string json = LootLockerJson.SerializeObject(input);
 
             LootLockerServerRequest.CallDomainAuthAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse, LootLockerJsonSettings.Indented); });
         }
@@ -119,7 +118,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = JsonConvert.SerializeObject(input);
+            string json = LootLockerJson.SerializeObject(input);
 
             LootLockerServerRequest.CallDomainAuthAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse, LootLockerJsonSettings.Indented); });
         }
@@ -128,7 +127,7 @@ namespace LootLocker
         {
             EndPointClass endPoint = LootLockerEndPoints.whiteLabelRequestPasswordReset;
 
-            var json = JsonConvert.SerializeObject(new { email });
+            var json = LootLockerJson.SerializeObject(new { email });
             LootLockerServerRequest.CallDomainAuthAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
 
@@ -136,7 +135,7 @@ namespace LootLocker
         {
             EndPointClass endPoint = LootLockerEndPoints.whiteLabelRequestAccountVerification;
 
-            var json = JsonConvert.SerializeObject(new { user_id = userID });
+            var json = LootLockerJson.SerializeObject(new { user_id = userID });
             LootLockerServerRequest.CallDomainAuthAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
 
@@ -144,7 +143,7 @@ namespace LootLocker
         {
             EndPointClass endPoint = LootLockerEndPoints.whiteLabelRequestAccountVerification;
 
-            var json = JsonConvert.SerializeObject(new { email = email });
+            var json = LootLockerJson.SerializeObject(new { email = email });
             LootLockerServerRequest.CallDomainAuthAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 LootLockerResponse response = new LootLockerResponse

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "url": "https://lootlocker.com"
   },
   "type": "tool",
-  "dependencies": {
-    "com.unity.nuget.newtonsoft-json": "3.0.2"
-  },
   "samples": [
         {
             "displayName": "LootLockerExamples",


### PR DESCRIPTION
I started removing our Newtonsoft includes and Visual Studio suggested this. I tried it in Unity 2022 and 2019. I tried it with our auto tests (included the [JsonProperty("public"] thing that I was worried about). I tried it with a project that used LL and had other files that used the external Newtonsoft package. So far I've found no problems, so this may be a viable way. Though when I google it I can't really find any indications on if it's a good idea or not which makes me a bit worried.