### PR TITLE
Increase client side timeout

### DIFF
--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -77,7 +77,6 @@ namespace LootLocker
                     webRequest.downloadHandler = new DownloadHandlerBuffer();
 
                     float startTime = Time.time;
-                    float maxTimeOutSeconds = 5f;
                     bool timedOut = false;
 
                     UnityWebRequestAsyncOperation unityWebRequestAsyncOperation = webRequest.SendWebRequest();
@@ -88,7 +87,7 @@ namespace LootLocker
                             return true;
                         }
 
-                        timedOut = !unityWebRequestAsyncOperation.isDone && Time.time - startTime >= maxTimeOutSeconds;
+                        timedOut = !unityWebRequestAsyncOperation.isDone && Time.time - startTime >= LootLockerConfig.current.clientSideRequestTimeOut;
 
                         return timedOut || unityWebRequestAsyncOperation.isDone;
 
@@ -96,7 +95,7 @@ namespace LootLocker
 
                     if (!webRequest.isDone && timedOut)
                     {
-                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Error)("Exceeded maxTimeOut waiting for a response from " + request.httpMethod + " " + url);
+                        LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("Exceeded maxTimeOut waiting for a response from " + request.httpMethod + " " + url);
                         OnServerResponse?.Invoke(new LootLockerResponse() { hasError = true, statusCode = 408, text = "{\"error\": \"" + request.endpoint + " Timed out.\"}", Error = request.endpoint + " Timed out." });
                         yield break;
                     }

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -176,7 +176,7 @@ namespace LootLocker
         [HideInInspector] public string playerUrl = UrlProtocol + UrlCore + PlayerUrlAppendage;
         [HideInInspector] public string userUrl = UrlProtocol + UrlCore + UserUrlAppendage;
         [HideInInspector] public string baseUrl = UrlProtocol + UrlCore;
-        [HideInInspector] public float clientSideRequestTimeOut = 10f;
+        [HideInInspector] public float clientSideRequestTimeOut = 5f;
         public enum DebugLevel { All, ErrorOnly, NormalOnly, Off , AllAsNormal}
         public DebugLevel currentDebugLevel = DebugLevel.All;
         public bool allowTokenRefresh = true;

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -176,6 +176,7 @@ namespace LootLocker
         [HideInInspector] public string playerUrl = UrlProtocol + UrlCore + PlayerUrlAppendage;
         [HideInInspector] public string userUrl = UrlProtocol + UrlCore + UserUrlAppendage;
         [HideInInspector] public string baseUrl = UrlProtocol + UrlCore;
+        [HideInInspector] public float clientSideRequestTimeOut = 10f;
         public enum DebugLevel { All, ErrorOnly, NormalOnly, Off , AllAsNormal}
         public DebugLevel currentDebugLevel = DebugLevel.All;
         public bool allowTokenRefresh = true;


### PR DESCRIPTION
Also reduce loglevel to warning as an error is returned anyways, it's up to the developer to handle the way they want
Also move configuration of the timeout limit to a central place