### PR TITLE
Make 'Other character' methods use player id as intended

### DIFF
--- a/Runtime/Client/LootLockerBaseServerAPI.cs
+++ b/Runtime/Client/LootLockerBaseServerAPI.cs
@@ -116,8 +116,10 @@ namespace LootLocker
                     LootLockerResponse response = new LootLockerResponse();
                     response.statusCode = (int)webRequest.responseCode;
 #if UNITY_2020_1_OR_NEWER
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("webRequest.result: " + webRequest.result + ", .error: " + webRequest.error);
                     if (webRequest.result == UnityWebRequest.Result.ProtocolError || webRequest.result == UnityWebRequest.Result.ConnectionError || !string.IsNullOrEmpty(webRequest.error))
 #else
+                    LootLockerLogger.GetForLogLevel(LootLockerLogger.LogLevel.Warning)("webRequest.isHttpError: " + webRequest.isHttpError + ", .isNetworkError: " + webRequest.isNetworkError + ", .error: " + webRequest.error);
                     if (webRequest.isHttpError || webRequest.isNetworkError || !string.IsNullOrEmpty(webRequest.error))
 #endif
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -1962,11 +1962,22 @@ namespace LootLocker.Requests
         }
 
         /// <summary>
-        /// Get a character loadout from a specific characterID.
+        /// Get a character loadout from a specific player on the current platform.
         /// </summary>
-        /// <param name="characterID">ID of the character</param>
+        /// <param name="player_id">ID of the player</param>
         /// <param name="onComplete">onComplete Action for handling the response of type LootLockerCharacterLoadoutResponse</param>
-        public static void GetOtherPlayersCharacterLoadout(string characterID, Action<LootLockerCharacterLoadoutResponse> onComplete)
+        public static void GetOtherPlayersCharacterLoadout(string player_id, Action<LootLockerCharacterLoadoutResponse> onComplete)
+        {
+            GetOtherPlayersCharacterLoadout(player_id, CurrentPlatform.Get(), onComplete);
+        }
+
+        /// <summary>
+        /// Get a character loadout from a specific player and platform
+        /// </summary>
+        /// <param name="player_id">ID of the player</param>
+        /// <param name="platform">The platform that the ID of the player is for</param>
+        /// <param name="onComplete">onComplete Action for handling the response of type LootLockerCharacterLoadoutResponse</param>
+        public static void GetOtherPlayersCharacterLoadout(string player_id, Platforms platform, Action<LootLockerCharacterLoadoutResponse> onComplete)
         {
             if (!CheckInitialized())
             {
@@ -1975,8 +1986,8 @@ namespace LootLocker.Requests
             }
             LootLockerGetRequest data = new LootLockerGetRequest();
 
-            data.getRequests.Add(characterID);
-            data.getRequests.Add(CurrentPlatform.GetString());
+            data.getRequests.Add(player_id);
+            data.getRequests.Add(CurrentPlatform.GetPlatformRepresentation(platform).PlatformString);
             LootLockerAPIManager.GetOtherPlayersCharacterLoadout(data, onComplete);
         }
 
@@ -2162,19 +2173,30 @@ namespace LootLocker.Requests
         }
 
         /// <summary>
-        /// Get the loadout for a specific character.
+        /// Get the current loadout for the default character of the specified player on the current platform
         /// </summary>
-        /// <param name="characterID">ID of the character to get the loadout for</param>
+        /// <param name="playerID">ID of the player to get the loadout for</param>
         /// <param name="onComplete">onComplete Action for handling the response of type LootLockerGetCurrentLoadouttoDefaultCharacterResponse</param>
-        public static void GetCurrentLoadOutToOtherCharacter(string characterID, Action<LootLockerGetCurrentLoadouttoDefaultCharacterResponse> onComplete)
+        public static void GetCurrentLoadOutToOtherCharacter(string playerID, Action<LootLockerGetCurrentLoadouttoDefaultCharacterResponse> onComplete)
+        {
+            GetCurrentLoadOutToOtherCharacter(playerID, CurrentPlatform.Get(), onComplete);
+        }
+
+        /// <summary>
+        /// Get the current loadout for the default character of the specified player and platform
+        /// </summary>
+        /// <param name="playerID">ID of the player to get the loadout for</param>
+        /// <param name="platform">The platform that the ID of the player is for</param>
+        /// <param name="onComplete">onComplete Action for handling the response of type LootLockerGetCurrentLoadouttoDefaultCharacterResponse</param>
+        public static void GetCurrentLoadOutToOtherCharacter(string playerID, Platforms platform, Action<LootLockerGetCurrentLoadouttoDefaultCharacterResponse> onComplete)
         {
             if (!CheckInitialized())
             {
                 onComplete?.Invoke(LootLockerResponseFactory.SDKNotInitializedError<LootLockerGetCurrentLoadouttoDefaultCharacterResponse>());
             }
             LootLockerGetRequest lootLockerGetRequest = new LootLockerGetRequest();
-            lootLockerGetRequest.getRequests.Add(characterID);
-            lootLockerGetRequest.getRequests.Add(CurrentPlatform.GetString());
+            lootLockerGetRequest.getRequests.Add(playerID);
+            lootLockerGetRequest.getRequests.Add(CurrentPlatform.GetPlatformRepresentation(platform).PlatformString);
             LootLockerAPIManager.GetCurrentLoadOutToOtherCharacter(lootLockerGetRequest, onComplete);
         }
 

--- a/Runtime/Game/Requests/CharacterRequest.cs
+++ b/Runtime/Game/Requests/CharacterRequest.cs
@@ -286,9 +286,9 @@ namespace LootLocker
 
         public static void GetCurrentLoadOutToOtherCharacter(LootLockerGetRequest lootLockerGetRequest, Action<LootLockerGetCurrentLoadouttoDefaultCharacterResponse> onComplete)
         {
-            EndPointClass endPoint = LootLockerEndPoints.getOtherPlayersCharacterLoadouts;
+            EndPointClass endPoint = LootLockerEndPoints.getOtherPlayersLoadoutToDefaultCharacter;
 
-            string getVariable = string.Format(endPoint.endPoint, lootLockerGetRequest.getRequests[0]);
+            string getVariable = string.Format(endPoint.endPoint, lootLockerGetRequest.getRequests[0], lootLockerGetRequest.getRequests[1]);
 
             LootLockerServerRequest.CallAPI(getVariable, endPoint.httpMethod, null, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }


### PR DESCRIPTION
I got these reported to me via DM:
```
hey, just wanted to report few things I found with the SDK 1.2.1

this function says GetOtherPlayersCharacterLoadout but the parameter has incorrect name and info it says characterId but should be playerId


the other thing is I'm getting this error with GetCurrentLoadOutToOtherCharacter

FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
System.Text.StringBuilder.AppendFormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) (at <b5ac4fa8faf34bc9be9b9c54f8ce8a43>:0)
System.String.FormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) (at <b5ac4fa8faf34bc9be9b9c54f8ce8a43>:0)
System.String.Format (System.String format, System.Object arg0) (at <b5ac4fa8faf34bc9be9b9c54f8ce8a43>:0)
LootLocker.LootLockerAPIManager.GetCurrentLoadOutToOtherCharacter (LootLocker.Requests.LootLockerGetRequest lootLockerGetRequest, System.Action1[T] onComplete) (at Assets/LootLockerSDK/Runtime/Game/Requests/CharacterRequest.cs:291)
LootLocker.Requests.LootLockerSDKManager.GetCurrentLoadOutToOtherCharacter (System.String characterID, System.Action1[T] onComplete) (at Assets/LootLockerSDK/Runtime/Game/LootLockerSDKManager.cs:2121) 

looks like its pointing to the wrong endpoint
```