### PR TITLE
Remove all deprecations in the Unity SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,9 @@ jobs:
           #- editmode
         unityVersion:
           - 2019.4.40f1
-          - 2020.3.38f1
-          - 2021.3.8f1
+          - 2020.3.48f1
+          - 2021.3.29f1
+          - 2022.3.7f1
     steps:
       - name: Checkout this repository
         uses: actions/checkout@v2

--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -144,24 +144,6 @@ namespace LootLocker
         public LootLockerErrorData errorData { get; set; }
 
         /// <summary>
-        /// TRUE if http error OR server returns an error status
-        /// </summary>
-        [Obsolete("This property is deprecated, use success instead")]
-        public bool hasError { get { return !success; } }
-
-        /// <summary>
-        /// If the request was not a success this property will hold any error messages
-        /// </summary>
-        [Obsolete("This property is deprecated, replaced by the errorData.message property")]
-        public string Error { get { return errorData?.message; } }
-
-        /// <summary>
-        /// A texture downloaded in the webrequest, if applicable, otherwise this will be null.
-        /// </summary>
-        [Obsolete("This property is deprecated")]
-        public Texture2D texture { get; set; }
-
-        /// <summary>
         /// inheritdoc added this because unity main thread executing style cut the calling stack and make the event orphan see also calling multiple events 
         /// of the same type makes use unable to identify each one
         /// </summary>
@@ -497,7 +479,7 @@ namespace LootLocker
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("domain-key", LootLockerConfig.current.domainKey);
 
-            if((!LootLockerConfig.current.IsPrefixedApiKey() && LootLockerConfig.current.developmentMode) || LootLockerConfig.current.apiKey.StartsWith("dev_"))
+            if(LootLockerConfig.current.apiKey.StartsWith("dev_"))
             {
                 headers.Add("is-development", "true");
             }

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -79,14 +79,6 @@ namespace LootLocker.Admin
                 gameSettings.apiKey = m_CustomSettings.FindProperty("apiKey").stringValue;
             }
 
-            bool deprecatedApiKey = !gameSettings.IsPrefixedApiKey();
-            if (deprecatedApiKey)
-            {
-                EditorGUILayout.HelpBox(
-                    "WARNING: this is a legacy API Key, please visit https://console.lootlocker.com/settings/api-keys and generate a new one",
-                    MessageType.Warning, false);
-            }
-
             var content = new GUIContent();
             content.text = "API key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys";
             EditorGUILayout.HelpBox(content, false);
@@ -129,19 +121,6 @@ namespace LootLocker.Admin
                 gameSettings.allowTokenRefresh = m_CustomSettings.FindProperty("allowTokenRefresh").boolValue; 
             }
             EditorGUILayout.Space();
-
-            if (deprecatedApiKey)
-            {
-                EditorGUI.BeginChangeCheck();
-                EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("developmentMode"));
-
-                if (EditorGUI.EndChangeCheck())
-                {
-                    gameSettings.developmentMode = m_CustomSettings.FindProperty("developmentMode").boolValue;
-                }
-
-                EditorGUILayout.Space();
-            }
         }
 
         [SettingsProvider]

--- a/Runtime/Game/Platforms/PlatformManager.cs
+++ b/Runtime/Game/Platforms/PlatformManager.cs
@@ -125,30 +125,6 @@ namespace LootLocker.Requests
             };
         }
 
-        // TODO: Deprecated, remove in version 1.2.0
-        public static void Set(LootLockerConfig.platformType platform)
-        {
-            switch (platform)
-            {
-                case LootLockerConfig.platformType.Android:
-                    Set(Platforms.Android);
-                    break;
-                case LootLockerConfig.platformType.iOS:
-                    Set(Platforms.AppleSignIn);
-                    break;
-                case LootLockerConfig.platformType.Steam:
-                    Set(Platforms.Steam);
-                    break;
-                case LootLockerConfig.platformType.PlayStationNetwork:
-                    Set(Platforms.PlayStationNetwork);
-                    break;
-                case LootLockerConfig.platformType.Unused:
-                default:
-                    Set(Platforms.None);
-                    break;
-            }
-        }
-
 
 #if UNITY_EDITOR
         [InitializeOnEnterPlayMode]

--- a/Runtime/Game/Requests/AssetRequest.cs
+++ b/Runtime/Game/Requests/AssetRequest.cs
@@ -183,12 +183,6 @@ namespace LootLocker.Requests
         public int[] favourites { get; set; }
     }
 
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerActivateRentalAssetResponse instead")]
-    public class LootLockerActivateARentalAssetResponse : LootLockerResponse
-    {
-        public int time_left { get; set; }
-    }
-
     public class LootLockerActivateRentalAssetResponse : LootLockerResponse
     {
         public int time_left { get; set; }

--- a/Runtime/Game/Requests/CollectableRequest.cs
+++ b/Runtime/Game/Requests/CollectableRequest.cs
@@ -11,12 +11,6 @@ namespace LootLocker.Requests
         public LootLockerCollectable[] collectables { get; set; }
     }
 
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerGetCollectablesResponse instead")]
-    public class LootLockerGettingCollectablesResponse : LootLockerResponse
-    {
-        public LootLockerCollectable[] collectables { get; set; }
-    }
-
     public class LootLockerCollectable
     {
         public string name { get; set; }
@@ -62,19 +56,6 @@ namespace LootLocker.Requests
         public string slug { get; set; }
     }
 
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerCollectItemResponse instead")]
-    public class LootLockerCollectingAnItemResponse : LootLockerResponse
-    {
-        public LootLockerCollectable[] collectables { get; set; }
-
-        public LootLockerCollectable mainCollectable { get; set; }
-
-        public LootLockerGroup mainGroup { get; set; }
-
-        public LootLockerItem mainItem { get; set; }
-
-    }
-
     public class LootLockerCollectItemResponse : LootLockerResponse
     {
         public LootLockerCollectable[] collectables { get; set; }
@@ -103,17 +84,6 @@ namespace LootLocker
             });
         }
 
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function GetCollectables() instead")]
-        public static void GettingCollectables(Action<LootLockerGettingCollectablesResponse> onComplete)
-        {
-            EndPointClass endPoint = LootLockerEndPoints.gettingCollectables;
-
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, "", (serverResponse) =>
-            {
-                onComplete?.Invoke(LootLockerResponse.Deserialize<LootLockerGettingCollectablesResponse>(serverResponse));
-            }, true);
-        }
-
         public static void CollectItem(LootLockerCollectingAnItemRequest data, Action<LootLockerCollectItemResponse> onComplete)
         {
             if(data == null)
@@ -132,44 +102,6 @@ namespace LootLocker
                 if (serverResponse.success)
                 {
                     response = LootLockerJson.DeserializeObject<LootLockerCollectItemResponse>(serverResponse.text);
-                    string[] collectableStrings = data.slug.Split('.');
-
-                    string collectable = collectableStrings[0];
-                    string group = collectableStrings[1];
-                    string item = collectableStrings[2];
-
-                    response.mainCollectable = response.collectables?.FirstOrDefault(x => x.name == collectable);
-                    response.mainGroup = response.mainCollectable?.groups?.FirstOrDefault(x => x.name == group);
-                    response.mainItem = response.mainGroup?.items?.FirstOrDefault(x => x.name == item);
-                }
-
-                response.text = serverResponse.text;
-                response.success = serverResponse.success;
-                response.errorData = serverResponse.errorData;
-                response.statusCode = serverResponse.statusCode;
-                onComplete?.Invoke(response);
-            }, true);
-        }
-
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function CollectItem() instead")]
-        public static void CollectingAnItem(LootLockerCollectingAnItemRequest data, Action<LootLockerCollectingAnItemResponse> onComplete)
-        {
-            if(data == null)
-            {
-            	onComplete?.Invoke(LootLockerResponseFactory.InputUnserializableError<LootLockerCollectingAnItemResponse>());
-            	return;
-            }
-
-            string json = LootLockerJson.SerializeObject(data);
-
-            EndPointClass endPoint = LootLockerEndPoints.collectingAnItem;
-
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
-            {
-                LootLockerCollectingAnItemResponse response = new LootLockerCollectingAnItemResponse();
-                if (serverResponse.success)
-                {
-                    response = LootLockerJson.DeserializeObject<LootLockerCollectingAnItemResponse>(serverResponse.text);
                     string[] collectableStrings = data.slug.Split('.');
 
                     string collectable = collectableStrings[0];

--- a/Runtime/Game/Requests/LootLockerSessionRequest.cs
+++ b/Runtime/Game/Requests/LootLockerSessionRequest.cs
@@ -27,37 +27,18 @@ namespace LootLocker.Requests
     {
         public string game_key => LootLockerConfig.current.apiKey?.ToString();
         public string email { get; set; }
-        public string password { get; set; } // DEPRECATED PARAMETER
         public string token { get; set; }
         public string game_version => LootLockerConfig.current.game_version;
-
-        [Obsolete("StartWhiteLabelSession with password is deprecated")]
-        public LootLockerWhiteLabelSessionRequest(string email, string password, string token)
-        {
-            this.email = email;
-            this.password = password;
-            this.token = token;
-        }
-
-        [Obsolete("StartWhiteLabelSession with password is deprecated")]
-        public LootLockerWhiteLabelSessionRequest(string email, string password)
-        {
-            this.email = email;
-            this.password = password;
-            this.token = null;
-        }
 
         public LootLockerWhiteLabelSessionRequest(string email)
         {
             this.email = email;
-            this.password = null;
             this.token = null;
         }
 
         public LootLockerWhiteLabelSessionRequest()
         {
             this.email = null;
-            this.password = null;
             this.token = null;
         }
     }
@@ -308,9 +289,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
+            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, LootLockerJson.SerializeObject(data), (serverResponse) =>
             {
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
@@ -329,9 +308,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
+            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, LootLockerJson.SerializeObject(data), (serverResponse) =>
             {
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
@@ -350,9 +327,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
+            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, LootLockerJson.SerializeObject(data), (serverResponse) =>
             {
                 var response = LootLockerResponse.Deserialize<LootLockerGuestSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
@@ -369,8 +344,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            GoogleSession(json, onComplete);
+            GoogleSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         public static void GoogleSession(LootLockerGoogleRefreshSessionRequest data, Action<LootLockerGoogleSessionResponse> onComplete)
@@ -381,8 +355,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            GoogleSession(json, onComplete);
+            GoogleSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         private static void GoogleSession(string json, Action<LootLockerGoogleSessionResponse> onComplete)
@@ -392,7 +365,6 @@ namespace LootLocker
             {
                 return;
             }
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerGoogleSessionResponse.Deserialize<LootLockerGoogleSessionResponse>(serverResponse);
@@ -413,10 +385,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
+            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, LootLockerJson.SerializeObject(data), (serverResponse) =>
             {
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
@@ -433,8 +402,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            EpicSession(json, onComplete);
+            EpicSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         public static void EpicSession(LootLockerEpicRefreshSessionRequest data, Action<LootLockerEpicSessionResponse> onComplete)
@@ -445,14 +413,12 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            EpicSession(json, onComplete);
+            EpicSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         private static void EpicSession(string json, Action<LootLockerEpicSessionResponse> onComplete)
         {
             EndPointClass endPoint = LootLockerEndPoints.epicSessionRequest;
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerResponse.Deserialize<LootLockerEpicSessionResponse>(serverResponse);
@@ -473,9 +439,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
+            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, LootLockerJson.SerializeObject(data), (serverResponse) =>
             {
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
@@ -492,8 +456,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            AppleSession(json, onComplete);
+            AppleSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         public static void AppleSession(LootLockerAppleRefreshSessionRequest data, Action<LootLockerAppleSessionResponse> onComplete)
@@ -504,8 +467,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            AppleSession(json, onComplete);
+            AppleSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         private static void AppleSession(string json, Action<LootLockerAppleSessionResponse> onComplete)
@@ -515,7 +477,6 @@ namespace LootLocker
             {
                 return;
             }
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerAppleSessionResponse.Deserialize<LootLockerAppleSessionResponse>(serverResponse);
@@ -534,8 +495,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            AppleGameCenterSession(json, onComplete);
+            AppleGameCenterSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         public static void AppleGameCenterSession(LootLockerAppleGameCenterRefreshSessionRequest data, Action<LootLockerAppleGameCenterSessionResponse> onComplete)
@@ -546,8 +506,7 @@ namespace LootLocker
                 return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            AppleGameCenterSession(json, onComplete);
+            AppleGameCenterSession(LootLockerJson.SerializeObject(data), onComplete);
         }
 
         private static void AppleGameCenterSession(string json, Action<LootLockerAppleGameCenterSessionResponse> onComplete)
@@ -557,7 +516,6 @@ namespace LootLocker
             {
                 return;
             }
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) =>
             {
                 var response = LootLockerAppleGameCenterSessionResponse.Deserialize<LootLockerAppleGameCenterSessionResponse>(serverResponse);
@@ -577,10 +535,7 @@ namespace LootLocker
             	return;
             }
 
-            string json = LootLockerJson.SerializeObject(data);
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
-
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
+            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, LootLockerJson.SerializeObject(data), (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
     }
 }

--- a/Runtime/Game/Requests/LootLockerVerifyRequest.cs
+++ b/Runtime/Game/Requests/LootLockerVerifyRequest.cs
@@ -43,7 +43,6 @@ namespace LootLocker
             	return;
             }
             string json = LootLockerJson.SerializeObject(data);
-            LootLockerConfig.AddDevelopmentModeFieldToJsonStringIfNeeded(ref json); // TODO: Deprecated, remove in version 1.2.0
             EndPointClass endPoint = LootLockerEndPoints.playerVerification;
 
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, false);

--- a/Runtime/Game/Requests/MapsRequest.cs
+++ b/Runtime/Game/Requests/MapsRequest.cs
@@ -49,15 +49,5 @@ namespace LootLocker
 
             LootLockerServerRequest.CallAPI(getVariable, endPoint.httpMethod, null, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
-
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function GetAllMaps() instead.")]
-        public static void GettingAllMaps(Action<LootLockerMapsResponse> onComplete)
-        {
-            EndPointClass endPoint = LootLockerEndPoints.gettingAllMaps;
-
-            string getVariable = endPoint.endPoint;
-
-            LootLockerServerRequest.CallAPI(getVariable, endPoint.httpMethod, null, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
-        }
     }
 }

--- a/Runtime/Game/Requests/MissionsRequest.cs
+++ b/Runtime/Game/Requests/MissionsRequest.cs
@@ -27,23 +27,10 @@ namespace LootLocker.Requests
         public LootLockerCheckpointTimes[] checkpoint_times { get; set; }
     }
 
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerFinishMissionRequest instead")]
-    public class LootLockerFinishingAMissionRequest : LootLockerGetRequest
-    {
-        public string signature { get; set; }
-        public LootLockerFinishingPayload payload { get; set; }
-    }
-
     public class LootLockerFinishMissionRequest : LootLockerGetRequest
     {
         public string signature { get; set; }
         public LootLockerFinishingPayload payload { get; set; }
-    }
-
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerGetAllMissionsResponse instead")]
-    public class LootLockerGettingAllMissionsResponse : LootLockerResponse
-    {
-        public LootLockerMission[] missions { get; set; }
     }
     
     public class LootLockerGetAllMissionsResponse : LootLockerResponse
@@ -51,34 +38,14 @@ namespace LootLocker.Requests
         public LootLockerMission[] missions { get; set; }
     }
 
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerGetMissionResponse isntead")]
-    public class LootLockerGettingASingleMissionResponse : LootLockerResponse
-    {
-        public LootLockerMission mission { get; set; }
-    }
-
     public class LootLockerGetMissionResponse : LootLockerResponse
     {
         public LootLockerMission mission { get; set; }
     }
 
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerStartMissionResponse instead")]
-    public class LootLockerStartingAMissionResponse : LootLockerResponse
-    {
-        public string signature { get; set; }
-    }
-
     public class LootLockerStartMissionResponse : LootLockerResponse
     {
         public string signature { get; set; }
-    }
-
-
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerFinishMissionResponse instead")]
-    public class LootLockerFinishingAMissionResponse : LootLockerResponse
-    {
-        public int score { get; set; }
-        public bool check_grant_notifications { get; set; }
     }
 
     public class LootLockerFinishMissionResponse : LootLockerResponse
@@ -99,25 +66,7 @@ namespace LootLocker
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
         }
 
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function GetAllMissions() instead")]
-        public static void GettingAllMissions(Action<LootLockerGettingAllMissionsResponse> onComplete)
-        {
-            EndPointClass endPoint = LootLockerEndPoints.gettingAllMissions;
-
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
-        }
-
         public static void GetMission(LootLockerGetRequest data, Action<LootLockerGetMissionResponse> onComplete)
-        {
-            EndPointClass requestEndPoint = LootLockerEndPoints.gettingASingleMission;
-
-            string endPoint = string.Format(requestEndPoint.endPoint, data.getRequests[0]);
-
-            LootLockerServerRequest.CallAPI(endPoint, requestEndPoint.httpMethod, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
-        }
-
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function GetMission() instead")]
-        public static void GettingASingleMission(LootLockerGetRequest data, Action<LootLockerGettingASingleMissionResponse> onComplete)
         {
             EndPointClass requestEndPoint = LootLockerEndPoints.gettingASingleMission;
 
@@ -135,38 +84,11 @@ namespace LootLocker
             LootLockerServerRequest.CallAPI(endPoint, requestEndPoint.httpMethod, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
         }
 
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function StartMission() instead")]
-        public static void StartingAMission(LootLockerGetRequest data, Action<LootLockerStartingAMissionResponse> onComplete)
-        {
-            EndPointClass requestEndPoint = LootLockerEndPoints.startingMission;
-
-            string endPoint = string.Format(requestEndPoint.endPoint, data.getRequests[0]);
-
-            LootLockerServerRequest.CallAPI(endPoint, requestEndPoint.httpMethod, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
-        }
-
         public static void FinishMission(LootLockerFinishMissionRequest data, Action<LootLockerFinishMissionResponse> onComplete)
         {
             if(data == null)
             {
             	onComplete?.Invoke(LootLockerResponseFactory.InputUnserializableError<LootLockerFinishMissionResponse>());
-            	return;
-            }
-
-            string json = LootLockerJson.SerializeObject(data);
-
-            EndPointClass requestEndPoint = LootLockerEndPoints.finishingMission;
-
-            string endPoint = string.Format(requestEndPoint.endPoint, data.getRequests[0]);
-
-            LootLockerServerRequest.CallAPI(endPoint, requestEndPoint.httpMethod, json, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
-        }
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function FinishMission() instead")]
-        public static void FinishingAMission(LootLockerFinishingAMissionRequest data, Action<LootLockerFinishingAMissionResponse> onComplete)
-        {
-            if(data == null)
-            {
-            	onComplete?.Invoke(LootLockerResponseFactory.InputUnserializableError<LootLockerFinishingAMissionResponse>());
             	return;
             }
 

--- a/Runtime/Game/Requests/PurchaseRequest.cs
+++ b/Runtime/Game/Requests/PurchaseRequest.cs
@@ -147,27 +147,7 @@ namespace LootLocker
             LootLockerServerRequest.CallAPI(getVariable, endPoint.httpMethod, "", (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
 
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function PollOrderStatus instead")]
-        public static void PollingOrderStatus(LootLockerGetRequest lootLockerGetRequest, Action<LootLockerCharacterLoadoutResponse> onComplete)
-        {
-            EndPointClass endPoint = LootLockerEndPoints.pollingOrderStatus;
-
-            string getVariable = string.Format(endPoint.endPoint, lootLockerGetRequest.getRequests[0]);
-
-            LootLockerServerRequest.CallAPI(getVariable, endPoint.httpMethod, "", (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
-        }
-
         public static void ActivateRentalAsset(LootLockerGetRequest lootLockerGetRequest, Action<LootLockerActivateRentalAssetResponse> onComplete)
-        {
-            EndPointClass endPoint = LootLockerEndPoints.activatingARentalAsset;
-
-            string getVariable = string.Format(endPoint.endPoint, lootLockerGetRequest.getRequests[0]);
-
-            LootLockerServerRequest.CallAPI(getVariable, endPoint.httpMethod, "", (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
-        }
-
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function ActivateRentalAsset instead")]
-        public static void ActivatingARentalAsset(LootLockerGetRequest lootLockerGetRequest, Action<LootLockerActivateARentalAssetResponse> onComplete)
         {
             EndPointClass endPoint = LootLockerEndPoints.activatingARentalAsset;
 

--- a/Runtime/Game/Requests/TriggerEventsRequest.cs
+++ b/Runtime/Game/Requests/TriggerEventsRequest.cs
@@ -4,26 +4,9 @@ using System.Collections.Generic;
 
 namespace LootLocker.Requests
 {
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerExecuteTriggerRequest instead")]
-    public class LootLockerTriggerAnEventRequest
-    {
-        public string name { get; set; }
-    }
-
-
     public class LootLockerExecuteTriggerRequest : LootLockerResponse
     {
         public string name { get; set; }
-    }
-
-
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerExecuteTriggerResponse instead")]
-    public class LootLockerTriggerAnEventResponse : LootLockerResponse
-    {
-        public bool check_grant_notifications { get; set; }
-        public LootLockerXp xp { get; set; }
-        public LootLockerLevel[] levels { get; set; }
-        public LootLockerGrantedAssets[] granted_assets { get; set; }
     }
 
     public class LootLockerExecuteTriggerResponse : LootLockerResponse
@@ -32,12 +15,6 @@ namespace LootLocker.Requests
         public LootLockerXp xp { get; set; }
         public LootLockerLevel[] levels { get; set; }
         public LootLockerGrantedAssets[] granted_assets { get; set; }
-    }
-
-    [Obsolete("This class is deprecated and will be removed at a later stage. Please use LootLockerListAllTriggersResponse instead")]
-    public class LootLockerListingAllTriggersResponse : LootLockerResponse
-    {
-        public string[] triggers { get; set; }
     }
 
     public class LootLockerListAllTriggersResponse : LootLockerResponse
@@ -112,31 +89,7 @@ namespace LootLocker
             LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
 
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function ExecuteTrigger() instead")]
-        public static void TriggeringAnEvent(LootLockerTriggerAnEventRequest data, Action<LootLockerTriggerAnEventResponse> onComplete)
-        {
-            if(data == null)
-            {
-            	onComplete?.Invoke(LootLockerResponseFactory.InputUnserializableError<LootLockerTriggerAnEventResponse>());
-            	return;
-            }
-
-            string json = LootLockerJson.SerializeObject(data);
-
-            EndPointClass endPoint = LootLockerEndPoints.triggeringAnEvent;
-
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, json, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
-        }
-
         public static void ListAllExecutedTriggers(Action<LootLockerListAllTriggersResponse> onComplete)
-        {
-            EndPointClass endPoint = LootLockerEndPoints.listingTriggeredTriggerEvents;
-
-            LootLockerServerRequest.CallAPI(endPoint.endPoint, endPoint.httpMethod, "", (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
-        }
-
-        [Obsolete("This function is deprecated and will be removed soon. Please use the function ListExecutedTriggers() instead")]
-        public static void ListingTriggeredTriggerEvents(Action<LootLockerListingAllTriggersResponse> onComplete)
         {
             EndPointClass endPoint = LootLockerEndPoints.listingTriggeredTriggerEvents;
 

--- a/Runtime/Game/Requests/WhiteLabelRequest.cs
+++ b/Runtime/Game/Requests/WhiteLabelRequest.cs
@@ -25,9 +25,6 @@ namespace LootLocker.Requests
     public class LootLockerWhiteLabelSignupResponse : LootLockerResponse
     {
         public int ID { get; set; }
-
-        [Obsolete("GameID is deprecated and will be removed soon")]
-        public int GameID { get; set; }
         public string Email { get; set; }
         public string CreatedAt { get; set; }
 

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -32,7 +32,6 @@ namespace LootLocker
             {
                 // Create a new Config
                 LootLockerConfig newConfig = ScriptableObject.CreateInstance<LootLockerConfig>();
-                newConfig.platform = platformType.Unused;
 
                 // Folder needs to exist for Unity to be able to create an asset in it
                 string dir = Application.dataPath+ "/LootLockerSDK/Resources/Config";
@@ -80,38 +79,17 @@ namespace LootLocker
             }
         }
 #endif
-        public static bool CreateNewSettings(string apiKey, string gameVersion, string domainKey, bool onDevelopmentMode = false, platformType platform = platformType.Unused, DebugLevel debugLevel = DebugLevel.All, bool allowTokenRefresh = false)
+        public static bool CreateNewSettings(string apiKey, string gameVersion, string domainKey, DebugLevel debugLevel = DebugLevel.All, bool allowTokenRefresh = false)
         {
             _current = Get();
 
             _current.apiKey = apiKey;
             _current.game_version = gameVersion;
-            if(platform != platformType.Unused) {
-                _current.platform = platform;
-            }
-            _current.developmentMode = onDevelopmentMode;
             _current.currentDebugLevel = debugLevel;
             _current.allowTokenRefresh = allowTokenRefresh;
             _current.domainKey = domainKey;
             _current.ConstructUrls();
             return true;
-        }
-
-        // TODO: Deprecated, remove in version 1.2.0
-        public bool IsPrefixedApiKey()
-        {
-            return !string.IsNullOrEmpty(apiKey) && (apiKey.StartsWith("dev_") || apiKey.StartsWith("prod_"));
-        }
-
-        // TODO: Deprecated, remove in version 1.2.0
-        public static void AddDevelopmentModeFieldToJsonStringIfNeeded(ref string json)
-        {
-            if (!current.IsPrefixedApiKey())
-            {
-                json = json.Remove(json.Length - 1, 1); // Remove '}'
-                string devModeJsonString = ", \"development_mode\": " + current.developmentMode;
-                json = json + devModeJsonString.ToLower() + "}";
-            }
         }
 
         private void ConstructUrls()
@@ -159,11 +137,6 @@ namespace LootLocker
         public string game_version = "1.0.0.0";
         [HideInInspector]
         public string deviceID = "defaultPlayerId";
-        [HideInInspector]
-        public platformType platform; // TODO: Deprecated, remove in version 1.2.0
-        public enum platformType { Android, iOS, Steam, PlayStationNetwork, Unused }
-        [HideInInspector]
-        public bool developmentMode = true;
 
         [HideInInspector] private static readonly string UrlProtocol = "https://";
         [HideInInspector] private static readonly string UrlCore = "api.lootlocker.io";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.lootlocker.lootlockersdk",
-  "version": "1.2.8",
+  "version": "2.0.0",
   "displayName": "LootLocker",
   "description": "LootLocker is a game backend-as-a-service with plug and play tools to upgrade your game and give your players the best experience possible. Designed for teams of all shapes and sizes, on mobile, PC and console. From solo developers, indie teams, AAA studios, and publishers. Built with cross-platform in mind.\n\n\u25AA Manage your game\nSave time and upgrade your game with leaderboards, progression, and more. Completely off-the-shelf features, built to work with any game and platform.\n\n\u25AA Manage your content\nTake charge of your game's content on all platforms, in one place. Sort, edit and manage everything, from cosmetics to currencies, UGC to DLC. Without breaking a sweat.\n\n\u25AA Manage your players\nStore your players' data together in one place. Access their profile and friends list cross-platform. Manage reports, messages, refunds and gifts to keep them hooked.\n",
   "unity": "2019.2",


### PR DESCRIPTION
### Deprecation List (Unity SDK)
* How you get error information from the SDK has changed. Instead of the fields hasError and Error in each response there is now a field named errorData within which all error information resides. Instead of hasError you use !success, and instead of Error you should use the fields in errorData. The exact replacement is errorData.message.
* The field "texture" on each response has been removed (it was never used)
* Dev Mode is deprecated, so is the "support" for deprecated api keys
* Game ID is no longer needed for White Label Signup
* When calling Init explicitly with parameters, then platform and onDevelopmentMode are no longer needed. The method now looks like this: `bool Init(string apiKey, string gameVersion, string domainKey)`
* `void StartSession(string deviceId, Action<LootLockerSessionResponse> onComplete)` is removed. If you're using this method you need to switch over to the topical start session methods instead. For example if you were using this to start a session for Android, then you should now use StartAndroidSession instead. If you're unsure of what to use, we recommend Guest or White Label.
* EndSession no longer takes deviceId as an argument, use `void EndSession(Action<LootLockerSessionResponse> onComplete)` instead
* Calling StartWhiteLabelSession with email and password is no longer supported. Instead, we cache the needed information and you should call `StartWhiteLabelSession(Action<LootLockerSessionResponse> onComplete)`. Or even better, replace the separate Login and StartSession calls with using `WhiteLabelLoginAndStartSession`
* All leaderboard methods that were using the leaderboard id (integer) have been removed. You should use the methods that take the leaderboard keys instead. The reason for this is that the leaderboard key is independent across environments meaning your code can stay the same when the game releases. Affected methods are:
    - GetMemberRank
    - GetByListOfMembers
    - GetScoreList
    - GetNextScoreList
    - GetPrevScoreList
    - GetScoreListOriginal
    - SubmitScore
* Starting a LootLocker Session from a White Label Login Token no longer needs a password in the request (LootLockerWhiteLabelSessionRequest)
* Renamed types (deprecated the old one, use the new one)
    - LootLockerActivateARentalAssetResponse renamed to LootLockerActivateRentalAssetResponse
    - LootLockerGettingCollectablesResponse renamed to LootLockerGetCollectablesResponse
    - LootLockerCollectingAnItemResponse renamed to LootLockerCollectItemResponse
    - LootLockerFinishingAMissionRequest renamed to LootLockerFinishMissionRequest
    - LootLockerGettingAllMissionsResponse renamed to LootLockerGetAllMissionsResponse
    - LootLockerGettingASingleMissionResponse renamed to LootLockerGetMissionResponse
    - LootLockerStartingAMissionResponse renamed to LootLockerStartMissionResponse
    - LootLockerFinishingAMissionResponse renamed to LootLockerFinishMissionResponse
    - LootLockerTriggerAnEventRequest renamed to LootLockerExecuteTriggerRequest
    - LootLockerTriggerAnEventResponse renamed to LootLockerExecuteTriggerResponse
    - LootLockerListingAllTriggersResponse renamed to LootLockerListAllTriggersResponse
* Renamed methods (deprecated the old one, use the new one)
    - GettingCollectables renamed to GetCollectables
    - CollectingAnItem renamed to CollectItem
    - GettingAllMaps renamed to GetAllMaps
    - GettingAllMissions renamed to GetAllMissions
    - GettingASingleMission renamed to GetMission
    - StartingAMission renamed to StartMission
    - FinishingAMission renamed to FinishMission
    - PollingOrderStatus renamed to PollOrderStatus
    - ActivatingARentalAsset renamed to ActivateRentalAsset
    - TriggeringAnEvent renamed to ExecuteTrigger
    - ListingTriggeredTriggerEvents renamed to ListAllExecutedTriggers