### PR TITLE
fix(runtime/game): DateTime acquisition_date is now nullable#19

### DIFF
--- a/Runtime/Game/Requests/PlayerRequest.cs
+++ b/Runtime/Game/Requests/PlayerRequest.cs
@@ -183,7 +183,7 @@ namespace LootLocker.Requests
         public int? variation_id { get; set; }
         public string rental_option_id { get; set; }
         public string acquisition_source { get; set; }
-        public DateTime acquisition_date { get; set; }
+        public DateTime? acquisition_date { get; set; }
         public LootLockerCommonAsset asset { get; set; }
         public LootLockerRental rental { get; set; }
 


### PR DESCRIPTION
task: https://github.com/orgs/lootlocker/projects/8/views/1?pane=issue&itemId=49667791

Tested with help from Mikkel - **Test OK** 👍 
![image](https://github.com/lootlocker/unity-sdk/assets/5321009/68380281-2456-4238-a6b3-d27551400013)
