### PR TITLE
Mark legacy keys in api key selection list

### DIFF
--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
@@ -708,6 +708,7 @@ namespace LootLocker.Extension
         {
             Button button = new Button();
 
+            bool isLegacyKey = !(key.api_key.StartsWith("prod_") || key.api_key.StartsWith("dev_"));
             button.name = key.api_key;
 
             Label keyName = new Label();
@@ -721,7 +722,15 @@ namespace LootLocker.Extension
                 button.style.borderRightColor = button.style.borderLeftColor = button.style.borderTopColor = button.style.borderBottomColor = stage;
             }
 
-            button.AddToClassList("apikey");
+            if (isLegacyKey)
+            {
+                keyName.text = "Legacy key: " + keyName.text;
+                button.AddToClassList("legacyApikey");
+            }
+            else
+            {
+                button.AddToClassList("apikey");
+            }
 
 
             keyName.AddToClassList("apikeyName");
@@ -729,7 +738,10 @@ namespace LootLocker.Extension
 
             button.Add(keyName);
 
-            button.clickable.clickedWithEventInfo += OnAPIKeySelected;
+            if (!isLegacyKey)
+            {
+                button.clickable.clickedWithEventInfo += OnAPIKeySelected;
+            }
 
             apiKeyList.Add(button);
         }

--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.uss
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.uss
@@ -57,6 +57,14 @@
     height: 40px;
 }
 
+.legacyApikey {
+    flex-direction: row;
+    width: 300px;
+    height: 40px;
+    background-color: #885555;
+    opacity: 0.5;
+}
+
 .clickable {
     cursor: link;
 }


### PR DESCRIPTION
I realized when updating the quick start guide for Unity that it's easy to get confused and use a legacy api key in the admin extension. So I marked those keys clearly and made them unclickable. This is how it looks:
<img width="404" alt="Legacy Key" src="https://github.com/lootlocker/unity-sdk/assets/4068377/958f3552-93b8-450b-9fcf-3afe9b8fa609">
