### PR TITLE
fix: changed LootLockerLeaderboardRewardPredicates to array

### DIFF
--- a/Runtime/Game/Requests/LeaderboardDetailsRequest.cs
+++ b/Runtime/Game/Requests/LeaderboardDetailsRequest.cs
@@ -266,7 +266,7 @@ namespace LootLocker.Requests
         /// <summary>
         /// The Predicates of the reward.
         /// </summary>
-        public LootLockerLeaderboardRewardPredicates predicates { get; set; }
+        public LootLockerLeaderboardRewardPredicates[] predicates { get; set; }
         /// <summary>
         /// The currency reward, will be null if the reward is of another type.
         /// </summary>


### PR DESCRIPTION
When Leaderboard Details first was introduced, I had missed that reward predicates are an array object, this commit will correct this mistake.