### PR TITLE
Change entity to string

### DIFF
--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -5440,7 +5440,7 @@ namespace LootLocker.Requests
 
             var request = new LootLockerFeedbackRequest
             {
-                entity = type,
+                entity = type.ToString(),
                 entity_id = ulid,
                 description = description,
                 category_id = category_id

--- a/Runtime/Game/Requests/FeedbackRequests.cs
+++ b/Runtime/Game/Requests/FeedbackRequests.cs
@@ -51,7 +51,7 @@ namespace LootLocker.Requests
         /// <summary>
         /// A string representation of the type of feedback
         /// </summary>
-        public LootLockerFeedbackTypes entity { get; set; }
+        public string entity { get; set; }
 
         /// <summary>
         /// The Ulid of what you're sending feedback about


### PR DESCRIPTION
Changed entity from LootLockerFeedbackTypes to a string, since just using the enum returns an int and the request requires a string.