### PR TITLE
Feature/metadata constructor

### DIFF
--- a/Runtime/Game/Requests/MetadataRequests.cs
+++ b/Runtime/Game/Requests/MetadataRequests.cs
@@ -197,8 +197,12 @@ namespace LootLocker.Requests
     /// </summary>
     public class LootLockerMetadataSourceAndKeys
     {
-        /// /// <summary>
-        /// Constructor for LootLockerMetadataSourceAndKeys
+        /// <summary>
+        /// Empty constructor for LootLockerMetadataSourceAndKeys
+        /// </summary>
+        public LootLockerMetadataSourceAndKeys() { }
+        /// <summary>
+        /// Constructor with parameters for LootLockerMetadataSourceAndKeys
         /// </summary>
         public LootLockerMetadataSourceAndKeys(LootLockerMetadataSources source, string id, string[] keys)
         {

--- a/Runtime/Game/Requests/MetadataRequests.cs
+++ b/Runtime/Game/Requests/MetadataRequests.cs
@@ -197,6 +197,15 @@ namespace LootLocker.Requests
     /// </summary>
     public class LootLockerMetadataSourceAndKeys
     {
+        /// /// <summary>
+        /// Constructor for LootLockerMetadataSourceAndKeys
+        /// </summary>
+        public LootLockerMetadataSourceAndKeys(LootLockerMetadataSources source, string id, string[] keys)
+        {
+            this.source = source;
+            this.id = id;
+            this.keys = keys;
+        }
         /// <summary>
         /// The type of source that the source id refers to
         /// </summary>


### PR DESCRIPTION
Added a constructor to LootLockerMetadataSourceAndKeys class as it makes it easier to create and add several values rather than setting all parameters manually.
Before, you had to do this:
```csharp
LootLockerMetadataSourceAndKeys[] entries = { new LootLockerMetadataSourceAndKeys(), new LootLockerMetadataSourceAndKeys() };
entries[0].id = "";
entries[0].keys = new string[] { "key1", "key2" };
entries[0].source = LootLocker.LootLockerEnums.LootLockerMetadataSources.reward;
LootLockerMetadataSourceAndKeys entry2 = new LootLockerMetadataSourceAndKeys();
entries[1].id = "";
entries[1].keys = new string[] { "key1", "key2" };
entries[1].source = LootLocker.LootLockerEnums.LootLockerMetadataSources.reward;
LootLockerSDKManager.GetMultisourceMetadata(entries, (response) =>
{...
```
And now you can instead do this:
```csharp
LootLockerMetadataSourceAndKeys[] array = { 
    new LootLockerMetadataSourceAndKeys(LootLocker.LootLockerEnums.LootLockerMetadataSources.leaderboard, ulid, new string[] { "info", "icon" }),
    new LootLockerMetadataSourceAndKeys(LootLocker.LootLockerEnums.LootLockerMetadataSources.leaderboard, ulid2, new string[] { "info", "icon" }) 
};
LootLockerSDKManager.GetMultisourceMetadata(array, (response) =>
{...
```
The old way is still supported, so a QOL improvement mostly.