### PR TITLE
Admin Extension Fixes

### DIFF
--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
@@ -609,13 +609,14 @@ namespace LootLocker.Extension
 
             LootLockerAdminManager.GetGameDomainKey(LootLockerEditorData.GetSelectedGame(), (onComplete) =>
             {
-                EditorApplication.update -= OnEditorUpdate;
                 if (!onComplete.success)
                 {
                     ShowPopup("Error", "Could not find Selected game!");
+                    EditorApplication.update -= OnEditorUpdate;
                     return;
                 }
                 LootLockerConfig.current.domainKey = onComplete.game.domain_key;
+                EditorApplication.update -= OnEditorUpdate;
             });
 
 

--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
@@ -609,14 +609,13 @@ namespace LootLocker.Extension
 
             LootLockerAdminManager.GetGameDomainKey(LootLockerEditorData.GetSelectedGame(), (onComplete) =>
             {
+                EditorApplication.update -= OnEditorUpdate;
                 if (!onComplete.success)
                 {
                     ShowPopup("Error", "Could not find Selected game!");
                     return;
                 }
                 LootLockerConfig.current.domainKey = onComplete.game.domain_key;
-
-                EditorApplication.update -= OnEditorUpdate;
             });
 
 

--- a/Runtime/Editor/LootLockerAdminEndPoints.cs
+++ b/Runtime/Editor/LootLockerAdminEndPoints.cs
@@ -16,7 +16,7 @@ namespace LootLocker
         [Header("User Information")]
         public static EndPointClass adminExtensionUserInformation = new EndPointClass("v1/user/all", LootLockerHTTPMethod.GET);
         public static EndPointClass adminExtensionGetUserRole = new EndPointClass("roles/{0}", LootLockerHTTPMethod.GET);
-        public static EndPointClass adminExtensionGetGameInformation = new EndPointClass("/game/{0}", LootLockerHTTPMethod.GET);
+        public static EndPointClass adminExtensionGetGameInformation = new EndPointClass("v1/game/{0}", LootLockerHTTPMethod.GET);
     }
 }
 #endif


### PR DESCRIPTION
- Fixed wrong endpoint
- Fixed that if the GetGameDomainKey request failed, we would stack several event-listeners and never remove them