### PR TITLE
Add support for player metadata

### DIFF
--- a/Runtime/Client/LootLockerEndPoints.cs
+++ b/Runtime/Client/LootLockerEndPoints.cs
@@ -299,6 +299,7 @@ namespace LootLocker
         [Header("Metadata")]
         public static EndPointClass listMetadata = new EndPointClass("metadata/source/{0}/id/{1}", LootLockerHTTPMethod.GET);
         public static EndPointClass getMultisourceMetadata = new EndPointClass("metadata/multisource", LootLockerHTTPMethod.POST);
+        public static EndPointClass metadataOperations = new EndPointClass("metadata", LootLockerHTTPMethod.POST);
 
         // Notifications
         [Header("Notifications")]

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -6,6 +6,7 @@ using System.Text;
 using LootLocker.LootLockerEnums;
 using System.Linq;
 using System.Security.Cryptography;
+using static UnityEngine.UIElements.UxmlAttributeDescription;
 #if LOOTLOCKER_USE_NEWTONSOFTJSON
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -5860,7 +5861,7 @@ namespace LootLocker.Requests
         /// Get Metadata for the specified source with the given key
         /// </summary>
         /// <param name="Source"> The source type for which to request metadata</param>
-        /// <param name="SourceID"> The specific source id for which to request metadata</param>
+        /// <param name="SourceID"> The specific source id for which to request metadata, note that if the source is self then this too should be set to "self"</param>
         /// <param name="Key"> The key of the metadata to fetch, use this to fetch metadata for a specific key for the specified source.</param>
         /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Optional: Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
@@ -5886,7 +5887,7 @@ namespace LootLocker.Requests
         /// <param name="SourcesAndKeysToGet"> The combination of sources to get keys for, and the keys to get for those sources </param>
         /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Optional: Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
-        public static void GetMultisourceMetadata(LootLockerMetadataSourceAndKeys[] SourcesAndKeysToGet, Action<LootLockerGetMultisourceMetadataResponse> onComplete, bool ignoreFiles = false)
+        public static void GetMultisourceMetadata(LootLockerMetadataSourceAndKeys[] SourcesAndKeysToGet, Action<LootLockerGetMultisourceMetadataResponse> onComplete, bool IgnoreFiles = false)
         {
             if (!CheckInitialized())
             {
@@ -5894,7 +5895,26 @@ namespace LootLocker.Requests
                 return;
             }
 
-            LootLockerAPIManager.GetMultisourceMetadata(SourcesAndKeysToGet, ignoreFiles, onComplete);
+            LootLockerAPIManager.GetMultisourceMetadata(SourcesAndKeysToGet, IgnoreFiles, onComplete);
+        }
+
+        /// <summary>
+        /// Perform the specified metadata operations for the specified source
+        /// Note that a subset of the specified operations can fail without the full request failing. Make sure to check the errors array in the response.
+        /// </summary>
+        /// <param name="Source"> The source type that the source id refers to </param>
+        /// <param name="SourceID"> The specific source id for which to set metadata, note that if the source is self then this too should be set to "self" </param>
+        /// <param name="OperationsToPerform"> List of operations to perform for the given source </param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
+        public static void PerformMetadataOperations(LootLockerMetadataSources Source, string SourceID, List<LootLockerMetadataOperation> OperationsToPerform, Action<LootLockerMetadataOperationsResponse> onComplete)
+        {
+            if (!CheckInitialized())
+            {
+                onComplete?.Invoke(LootLockerResponseFactory.SDKNotInitializedError<LootLockerMetadataOperationsResponse>());
+                return;
+            }
+
+            LootLockerAPIManager.PerformMetadataOperations(Source, SourceID, OperationsToPerform, onComplete);
         }
         #endregion
 

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -102,6 +102,7 @@ namespace LootLocker.Requests
                 LootLockerConfig.current.token = "";
                 LootLockerConfig.current.refreshToken = "";
                 LootLockerConfig.current.deviceID = "";
+                LootLockerConfig.current.playerULID = null;
                 if (!Init())
                 {
                     return false;
@@ -211,6 +212,7 @@ namespace LootLocker.Requests
                 {
                     CurrentPlatform.Reset();
                 }
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete(response);
             });
         }
@@ -239,6 +241,7 @@ namespace LootLocker.Requests
                 {
                     CurrentPlatform.Reset();
                 }
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete(response);
             });
         }
@@ -267,6 +270,7 @@ namespace LootLocker.Requests
                 {
                     CurrentPlatform.Reset();
                 }
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete(response);
             });
         }
@@ -762,6 +766,7 @@ namespace LootLocker.Requests
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.refreshToken = response.refresh_token;
                 LootLockerConfig.current.deviceID = "";
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -807,6 +812,7 @@ namespace LootLocker.Requests
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.refreshToken = response.refresh_token;
                 LootLockerConfig.current.deviceID = "";
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -852,6 +858,7 @@ namespace LootLocker.Requests
 
             LootLockerConfig.current.token = "";
             LootLockerConfig.current.deviceID = "";
+            LootLockerConfig.current.playerULID = null;
             LootLockerConfig.current.refreshToken = "";
         }
         #endregion

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -5801,7 +5801,7 @@ namespace LootLocker.Requests
         /// </summary>
         /// <param name="Source"> The source type for which to request metadata</param>
         /// <param name="SourceID"> The specific source id for which to request metadata</param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
         public static void ListMetadata(LootLockerMetadataSources Source, string SourceID, Action<LootLockerListMetadataResponse> onComplete, bool IgnoreFiles = false)
         {
@@ -5815,7 +5815,7 @@ namespace LootLocker.Requests
         /// <param name="SourceID"> The specific source id for which to request metadata</param>
         /// <param name="Page"> Used together with PerPage to apply pagination to this request. Page designates which "page" of items to fetch</param>
         /// <param name="PerPage"> Used together with Page to apply pagination to this request.PerPage designates how many items are considered a "page"</param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
         public static void ListMetadata(LootLockerMetadataSources Source, string SourceID, int Page, int PerPage, Action<LootLockerListMetadataResponse> onComplete, bool IgnoreFiles = false)
         {
@@ -5828,7 +5828,7 @@ namespace LootLocker.Requests
         /// <param name="Source"> The source type for which to request metadata</param>
         /// <param name="SourceID"> The specific source id for which to request metadata</param>
         /// <param name="Tags"> The tags that the requested metadata should have, only metadata matching *all of* the given tags will be returned </param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
         public static void ListMetadataWithTags(LootLockerMetadataSources Source, string SourceID, string[] Tags, Action<LootLockerListMetadataResponse> onComplete, bool IgnoreFiles = false)
         {
@@ -5843,7 +5843,7 @@ namespace LootLocker.Requests
         /// <param name="Tags"> The tags that the requested metadata should have, only metadata matching *all of* the given tags will be returned </param>
         /// <param name="Page"> Used together with PerPage to apply pagination to this request.Page designates which "page" of items to fetch</param>
         /// <param name="PerPage"> Used together with Page to apply pagination to this request.PerPage designates how many items are considered a "page"</param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
         public static void ListMetadataWithTags(LootLockerMetadataSources Source, string SourceID, string[] Tags, int Page, int PerPage, Action<LootLockerListMetadataResponse> onComplete, bool IgnoreFiles = false)
         {
@@ -5862,7 +5862,7 @@ namespace LootLocker.Requests
         /// <param name="Source"> The source type for which to request metadata</param>
         /// <param name="SourceID"> The specific source id for which to request metadata</param>
         /// <param name="Key"> The key of the metadata to fetch, use this to fetch metadata for a specific key for the specified source.</param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Optional: Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
         public static void GetMetadata(LootLockerMetadataSources Source, string SourceID, string Key, Action<LootLockerGetMetadataResponse> onComplete, bool IgnoreFiles=false)
         {
@@ -5884,7 +5884,7 @@ namespace LootLocker.Requests
         /// List the requested page of Metadata for the specified source that has all of the provided tags and paginate according to the supplied pagination settings
         /// </summary>
         /// <param name="SourcesAndKeysToGet"> The combination of sources to get keys for, and the keys to get for those sources </param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         /// <param name="IgnoreFiles"> Optional: Base64 values will be set to content_type "application/x-redacted" and the content will be an empty String. Use this to avoid accidentally fetching large data files.</param>
         public static void GetMultisourceMetadata(LootLockerMetadataSourceAndKeys[] SourcesAndKeysToGet, Action<LootLockerGetMultisourceMetadataResponse> onComplete, bool ignoreFiles = false)
         {
@@ -5903,7 +5903,7 @@ namespace LootLocker.Requests
         /// <summary>
         /// List notifications without filters and with default pagination settings
         /// </summary>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         public static void ListNotificationsWithDefaultParameters(Action<LootLockerListNotificationsResponse> onComplete)
         {
             if (!CheckInitialized())
@@ -5942,7 +5942,7 @@ namespace LootLocker.Requests
         /// <param name="PerPage">(Optional) Used together with Page to apply pagination to this request. PerPage designates how many notifications are considered a "page". Set to 0 to not use this filter.</param>
         /// <param name="Page">(Optional) Used together with PerPage to apply pagination to this request. Page designates which "page" of items to fetch. Set to 0 to not use this filter.</param>
         /// <param name="onComplete"></param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         public static void ListNotifications(bool ShowRead, LootLockerNotificationPriority? WithPriority, string OfType, string WithSource, int PerPage, int Page, Action<LootLockerListNotificationsResponse> onComplete)
         {
             if (!CheckInitialized())
@@ -5982,7 +5982,7 @@ namespace LootLocker.Requests
         ///
         /// Warning: This will mark ALL unread notifications as read, so if you have listed notifications but due to filters and/or pagination not pulled all of them you may have unviewed unread notifications
         /// </summary>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         public static void MarkAllNotificationsAsRead(Action<LootLockerReadNotificationsResponse> onComplete)
         {
             if (!CheckInitialized())
@@ -5998,7 +5998,7 @@ namespace LootLocker.Requests
         /// Mark the specified notifications as read
         /// </summary>
         /// <param name="NotificationIds">List of ids of notifications to mark as read</param>
-        /// <param name="OnComplete">Delegate for handling the server response</param>
+        /// <param name="onComplete">Delegate for handling the server response</param>
         public static void MarkNotificationsAsRead(string[] NotificationIds, Action<LootLockerReadNotificationsResponse> onComplete)
         {
             if (!CheckInitialized())

--- a/Runtime/Game/Requests/EntitlementRequests.cs.meta
+++ b/Runtime/Game/Requests/EntitlementRequests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 930b5026c070b2d4fb183ec255103c0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Game/Requests/LootLockerSessionRequest.cs
+++ b/Runtime/Game/Requests/LootLockerSessionRequest.cs
@@ -343,6 +343,7 @@ namespace LootLocker
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.deviceID = data?.player_identifier;
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -381,6 +382,7 @@ namespace LootLocker
                 var response = LootLockerResponse.Deserialize<LootLockerGuestSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.deviceID = (data as LootLockerSessionRequest)?.player_identifier;
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -439,6 +441,7 @@ namespace LootLocker
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.deviceID = "";
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -474,6 +477,7 @@ namespace LootLocker
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.refreshToken = response.refresh_token;
                 LootLockerConfig.current.deviceID = "";
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -493,6 +497,7 @@ namespace LootLocker
                 var response = LootLockerResponse.Deserialize<LootLockerSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.deviceID = "";
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 onComplete?.Invoke(response);
             }, false);
         }
@@ -531,6 +536,7 @@ namespace LootLocker
                 var response = LootLockerAppleSessionResponse.Deserialize<LootLockerAppleSessionResponse>(serverResponse);
                 LootLockerConfig.current.token = response.session_token;
                 LootLockerConfig.current.deviceID = response.player_identifier;
+                LootLockerConfig.current.playerULID = response.player_ulid;
                 LootLockerConfig.current.refreshToken = response.refresh_token;
                 onComplete?.Invoke(response);
             }, false);

--- a/Runtime/Game/Requests/MetadataRequests.cs
+++ b/Runtime/Game/Requests/MetadataRequests.cs
@@ -23,6 +23,8 @@ namespace LootLocker.LootLockerEnums
         catalog_item = 2,
         progression = 3,
         currency = 4,
+        player = 5,
+        self = 6
     };
 
     /// <summary>
@@ -291,6 +293,10 @@ namespace LootLocker
     {
         public static void ListMetadata(LootLockerMetadataSources Source, string SourceID, int Page, int PerPage, string Key, string[] Tags, bool ignoreFiles, Action<LootLockerListMetadataResponse> onComplete)
         {
+            if (Source == LootLockerMetadataSources.self)
+            {
+                SourceID = "self";
+            }
             string formattedEndpoint = string.Format(LootLockerEndPoints.listMetadata.endPoint, Source.ToString(), SourceID);
 
             string queryParams = "";
@@ -333,6 +339,14 @@ namespace LootLocker
             {
                 queryParams = $"?{queryParams}";
                 endpoint += queryParams;
+            }
+
+            foreach ( var sourcePair in SourcesAndKeysToGet)
+            {
+                if(sourcePair.source == LootLockerMetadataSources.self)
+                {
+                    sourcePair.id = "self";
+                }
             }
 
             LootLockerGetMultisourceMetadataRequest request = new LootLockerGetMultisourceMetadataRequest { sources = SourcesAndKeysToGet };

--- a/Runtime/Game/Requests/MetadataRequests.cs
+++ b/Runtime/Game/Requests/MetadataRequests.cs
@@ -453,13 +453,13 @@ namespace LootLocker
                 });
         }
 
-        public static void PerformMetadataOperations(LootLockerMetadataSources Source, string SourceID, List<LootLockerMetadataOperation> operationsToPerform, Action<LootLockerMetadataOperationsResponse> onComplete)
+        public static void PerformMetadataOperations(LootLockerMetadataSources Source, string SourceID, List<LootLockerMetadataOperation> OperationsToPerform, Action<LootLockerMetadataOperationsResponse> onComplete)
         {
             if (Source == LootLockerMetadataSources.self)
             {
                 SourceID = "self";
             }
-            if (string.IsNullOrEmpty(SourceID) || operationsToPerform.Count == 0)
+            if (string.IsNullOrEmpty(SourceID) || OperationsToPerform.Count == 0)
             {
                 onComplete?.Invoke(LootLockerResponseFactory.InputUnserializableError<LootLockerMetadataOperationsResponse>());
                 return;
@@ -470,7 +470,7 @@ namespace LootLocker
                 self = Source == LootLockerMetadataSources.self,
                 source = Source.ToString().ToLower(),
                 source_id = SourceID,
-                entries = operationsToPerform.ToArray()
+                entries = OperationsToPerform.ToArray()
             };
 
             string json = LootLockerJson.SerializeObject(request);

--- a/Runtime/Game/Requests/MetadataRequests.cs
+++ b/Runtime/Game/Requests/MetadataRequests.cs
@@ -248,11 +248,11 @@ namespace LootLocker.Requests
     public class LootLockerMetadataOperationErrorKeyTypePair
     {
         /// <summary>
-        /// TODO: Document
+        /// The metadata key that the operation error refers to
         /// </summary>
         public string key { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// The type of value that the set operation was for
         /// </summary>
         public LootLockerMetadataTypes type { get; set; }
     }
@@ -262,15 +262,15 @@ namespace LootLocker.Requests
     public class LootLockerMetadataOperationError
     {
         /// <summary>
-        /// TODO: Document
+        /// The type of action that this metadata operation was
         /// </summary>
         public LootLockerMetadataActions action { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// The error message describing why this metadata set operation failed
         /// </summary>
         public string error { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// The key and type of value that the operation was for
         /// </summary>
         public LootLockerMetadataOperationErrorKeyTypePair entry { get; set; }
     }
@@ -280,7 +280,7 @@ namespace LootLocker.Requests
     public class LootLockerMetadataOperation : LootLockerMetadataEntry
     {
         /// <summary>
-        /// TODO: Document
+        /// The type of action to perform for this metadata operation
         /// </summary>
         LootLockerMetadataActions action { get; set; }
     }
@@ -302,19 +302,19 @@ namespace LootLocker.Requests
     public class LootLockerMetadataOperationRequest
     {
         /// <summary>
-        /// TODO: Document
+        /// Whether or not this operation is for metadata on the current player
         /// </summary>
         public bool self { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// The type of source that the source id refers to
         /// </summary>
         public string source { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// The id of the specific source that the set operation was taken on, note that if source is set to self then this should also be set to "self"
         /// </summary>
         public string source_id { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// List of operations to perform for the given source
         /// </summary>
         public LootLockerMetadataOperation[] entries { get; set; }
 
@@ -362,15 +362,15 @@ namespace LootLocker.Requests
     public class LootLockerMetadataOperationsResponse : LootLockerResponse
     {
         /// <summary>
-        /// TODO: Document
+        /// The type of source that the source id refers to
         /// </summary>
         public LootLockerMetadataSources source { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// The id of the specific source that the set operation was taken on, note that if source is set to self then this will also be set to "self"
         /// </summary>
         public string source_id { get; set; }
         /// <summary>
-        /// TODO: Document
+        /// A list of errors (if any) that occurred when executing the provided metadata actions
         /// </summary>
         public LootLockerMetadataOperationError[] errors { get; set; }
     }
@@ -483,3 +483,4 @@ namespace LootLocker
         }
     }
 }
+    

--- a/Runtime/Game/Requests/NotificationRequests.cs.meta
+++ b/Runtime/Game/Requests/NotificationRequests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: a11c5f1533dceae4d8799c6dae914b18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Game/Requests/RemoteSessionRequest.cs
+++ b/Runtime/Game/Requests/RemoteSessionRequest.cs
@@ -422,6 +422,7 @@ namespace LootLocker
                     var response = LootLockerResponse.Deserialize<LootLockerRefreshRemoteSessionResponse>(serverResponse);
                     LootLockerConfig.current.token = response.session_token;
                     LootLockerConfig.current.deviceID = response.player_identifier;
+                    LootLockerConfig.current.playerULID = response.player_ulid;
                     LootLockerConfig.current.refreshToken = response.refresh_token;
                     onComplete?.Invoke(response);
                 }, false);
@@ -465,6 +466,7 @@ namespace LootLocker
                         LootLockerConfig.current.token = response.session_token;
                         LootLockerConfig.current.refreshToken = response.refresh_token;
                         LootLockerConfig.current.deviceID = response.player_ulid;
+                        LootLockerConfig.current.playerULID = response.player_ulid;
                     }
 
                     onComplete?.Invoke(response);

--- a/Runtime/Game/Requests/TriggersRequests.cs.meta
+++ b/Runtime/Game/Requests/TriggersRequests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 3dc7e3933992c4d47a520c462a23a5f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -260,6 +260,8 @@ namespace LootLocker
         public string sdk_version = "";
         [HideInInspector]
         public string deviceID = "defaultPlayerId";
+        [HideInInspector]
+        public string playerULID = null;
 
         [HideInInspector] private static readonly string UrlProtocol = "https://";
         [HideInInspector] private static readonly string UrlCore = "api.lootlocker.com";

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationApiKey.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationApiKey.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 1e8e8f9f8a14132479da6cdbbd287815
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationAuth.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationAuth.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: f85bbe24a6ce9ec42851790a601c3858
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationEndpoints.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationEndpoints.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 6e94b60506262ef44a38bed7df609a14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationGame.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationGame.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: a36b87e67d8db5b4f843df457df6881e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationPlatform.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationPlatform.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 1252b2268cd963b4e9853e4776f0d390
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationTrigger.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationTrigger.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 8329348febe498645aec6eefed048c88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationUser.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationUser.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: e6eb3c3689559ac4094d0cca04e4af58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationUtilities.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationUtilities.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 10afc8ae64434114e83ea5b1349b6cf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTests/PlayMode/NotificationTests.cs.meta
+++ b/Tests/LootLockerTests/PlayMode/NotificationTests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: a312577a03f272b4eb7fa47e690b62f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTests/PlayMode/PingTest.cs.meta
+++ b/Tests/LootLockerTests/PlayMode/PingTest.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: e17ef1f40aaf640489205deaa72b80b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/LootLockerTests/PlayMode/TriggerTests.cs.meta
+++ b/Tests/LootLockerTests/PlayMode/TriggerTests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: fa900594158c9d74291136910755dd52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This contains two ugly workarounds mentioned below, but has now been tested and works.
Workarounds:
- Backend needs enum values lowercased, so the request body for metadata operations converts the operations list to a new internal type that has the enums as strings and forces them to be lowercase. This is memory and cycle waste but is unfortunately how it needs to be at the moment.
- When operations are performed to self, then the source field and source id field need to be either dropped or set to something valid. So I opted for setting it to the current player ULID.