### PR TITLE
fix: Null guard all UI elements in samples

### DIFF
--- a/Runtime/Client/LootLockerServerRequest.cs
+++ b/Runtime/Client/LootLockerServerRequest.cs
@@ -182,13 +182,13 @@ namespace LootLocker
             }
 
             //Print the most important info first
-            string prettyError = $"LootLocker Error: \"{message}\"";
+            string prettyError = $"LootLocker Error: \"{message ?? ""}\"";
 
             // Look for intermittent, non user errors
             if (!string.IsNullOrEmpty(code) && code.StartsWith("HTTP5"))
             {
                 prettyError +=
-                    $"\nTry again later. If the issue persists, please contact LootLocker support and provide the following error details:\n trace ID - \"{trace_id}\",\n request ID - \"{request_id}\",\n message - \"{message}\".";
+                    $"\nTry again later. If the issue persists, please contact LootLocker support and provide the following error details:\n trace ID - \"{trace_id ?? ""}\",\n request ID - \"{request_id ?? ""}\",\n message - \"{message ?? ""}\".";
                 if (!string.IsNullOrEmpty(doc_url))
                 {
                     prettyError += $"\nFor more information, see {doc_url} (error code was \"{code}\").";
@@ -199,14 +199,14 @@ namespace LootLocker
             {
                 prettyError +=
                     $"\nThere was a problem with your request. The error message provides information on the problem and will help you fix it.";
-                if (!string.IsNullOrEmpty(doc_url))
+                if (!string.IsNullOrEmpty(doc_url ?? ""))
                 {
-                    prettyError += $"\nFor more information, see {doc_url} (error code was \"{code}\").";
+                    prettyError += $"\nFor more information, see {doc_url ?? ""} (error code was \"{code ?? ""}\").";
                 }
 
                 prettyError +=
                     $"\nIf you are unable to fix the issue, contact LootLocker support and provide the following error details:";
-                if (!string.IsNullOrEmpty(trace_id))
+                if (!string.IsNullOrEmpty(trace_id ?? ""))
                 {
                     prettyError += $"\n     trace ID - \"{trace_id}\"";
                 }
@@ -215,7 +215,7 @@ namespace LootLocker
                     prettyError += $"\n     request ID - \"{request_id}\"";
                 }
 
-                prettyError += $"\n     message - \"{message}\".";
+                prettyError += $"\n     message - \"{message ?? ""}\".";
             }
             return prettyError;
         }

--- a/Samples~/LootLockerExamples/1a - GuestLoginLootLockerIdentifier/GuestLoginLootLockerIdentifier.cs
+++ b/Samples~/LootLockerExamples/1a - GuestLoginLootLockerIdentifier/GuestLoginLootLockerIdentifier.cs
@@ -1,26 +1,33 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using LootLocker.Requests;
 using UnityEngine.UI;
 
-namespace LootLocker {
-public class GuestLoginLootLockerIdentifier : MonoBehaviour
+namespace LootLocker
+{
+    public class GuestLoginLootLockerIdentifier : MonoBehaviour
 {
     public Text loginInformationText;
     public Text playerIdText;
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(DoGuestLogin());
+    }
+
+    IEnumerator DoGuestLogin()
+    {
+        // Wait until end of frame to ensure that the UI has been loaded
+        yield return new WaitForEndOfFrame();
         /* 
-         * Override settings to use the Example game setup
-         */
+        * Override settings to use the Example game setup
+        */
         LootLockerSettingsOverrider.OverrideSettings();
 
         /* Start guest session without an identifier.
-         * LootLocker will create an identifier for the user and store it in PlayerPrefs.
-         * If you want to create a new player when testing, you can use PlayerPrefs.DeleteKey("LootLockerGuestPlayerID");
-         */
+        * LootLocker will create an identifier for the user and store it in PlayerPrefs.
+        * If you want to create a new player when testing, you can use PlayerPrefs.DeleteKey("LootLockerGuestPlayerID");
+        */
         LootLockerSDKManager.StartGuestSession((response) =>
         {
             if(response.success)
@@ -30,7 +37,7 @@ public class GuestLoginLootLockerIdentifier : MonoBehaviour
             }
             else
             {
-                loginInformationText.text = "Error" + response.errorData.message;
+                loginInformationText.text = "Error" + response.errorData.ToString();
             }
         });
     }

--- a/Samples~/LootLockerExamples/1b - GuestLoginUniqueIdentifier/GuestLoginUniqueIdentifier.cs
+++ b/Samples~/LootLockerExamples/1b - GuestLoginUniqueIdentifier/GuestLoginUniqueIdentifier.cs
@@ -12,15 +12,22 @@ public class GuestLoginUniqueIdentifier : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(DoGuestLogin());
+    }
+
+    IEnumerator DoGuestLogin()
+    {
+        // Wait until end of frame to ensure that the UI has been loaded
+        yield return new WaitForEndOfFrame();
         /* 
-         * Override settings to use the Example games setup
-         */
+        * Override settings to use the Example games setup
+        */
         LootLockerSettingsOverrider.OverrideSettings();
 
         /* Start guest session with an unique identifier tied to this device.
-         * So if someone uninstall your game, they will be able to log in again when they reinstall to the 
-         * same account as long as they are using the same device.
-         */
+        * So if someone uninstall your game, they will be able to log in again when they reinstall to the 
+        * same account as long as they are using the same device.
+        */
         LootLockerSDKManager.StartGuestSession(SystemInfo.deviceUniqueIdentifier, (response) =>
         {
             if(response.success)
@@ -30,7 +37,7 @@ public class GuestLoginUniqueIdentifier : MonoBehaviour
             }
             else
             {
-                loginInformationText.text = "Error" + response.errorData.message;
+                loginInformationText.text = "Error" + response.errorData.ToString();
             }
         });
     }

--- a/Samples~/LootLockerExamples/2a - PlayerTypeLeaderboard/PlayerTypeLeaderboard.cs
+++ b/Samples~/LootLockerExamples/2a - PlayerTypeLeaderboard/PlayerTypeLeaderboard.cs
@@ -28,6 +28,13 @@ namespace LootLocker
         // Start is called before the first frame update
         void Start()
         {
+            StartCoroutine(DoLoginAndSetUp());
+        }
+
+        IEnumerator DoLoginAndSetUp()
+        {
+            // Wait until end of frame to ensure that the UI has been loaded
+            yield return new WaitForEndOfFrame();
             /* 
              * Override settings to use the Example game setup
              */

--- a/Samples~/LootLockerExamples/2b - GenericTypeLeaderboardArcadeStyle/GenericTypeLeaderboard.cs
+++ b/Samples~/LootLockerExamples/2b - GenericTypeLeaderboardArcadeStyle/GenericTypeLeaderboard.cs
@@ -28,6 +28,13 @@ public class GenericTypeLeaderboard : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(DoLoginAndSetUp());
+    }
+
+    IEnumerator DoLoginAndSetUp()
+    {
+        // Wait until end of frame to ensure that the UI has been loaded
+        yield return new WaitForEndOfFrame();
         /* 
          * Override settings to use the Example game setup
          */

--- a/Samples~/LootLockerExamples/2c - FloatLeaderboard/FloatLeaderboard.cs
+++ b/Samples~/LootLockerExamples/2c - FloatLeaderboard/FloatLeaderboard.cs
@@ -28,6 +28,13 @@ public class FloatLeaderboard : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(DoLoginAndSetUp());
+    }
+
+    IEnumerator DoLoginAndSetUp()
+    {
+        // Wait until end of frame to ensure that the UI has been loaded
+        yield return new WaitForEndOfFrame();
         /* 
          * Override settings to use the Example game setup
          */

--- a/Samples~/LootLockerExamples/3 - PlayerNames/PlayerNames.cs
+++ b/Samples~/LootLockerExamples/3 - PlayerNames/PlayerNames.cs
@@ -15,6 +15,13 @@ public class PlayerNames : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(DoLoginAndSetUp());
+    }
+
+    IEnumerator DoLoginAndSetUp()
+    {
+        // Wait until end of frame to ensure that the UI has been loaded
+        yield return new WaitForEndOfFrame();
         /* 
          * Override settings to use the Example game setup
          */

--- a/Samples~/LootLockerExamples/4 - PlayerStorage/PlayerStorage.cs
+++ b/Samples~/LootLockerExamples/4 - PlayerStorage/PlayerStorage.cs
@@ -18,6 +18,13 @@ public class PlayerStorage : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(DoLoginAndSetUp());
+    }
+
+    IEnumerator DoLoginAndSetUp()
+    {
+        // Wait until end of frame to ensure that the UI has been loaded
+        yield return new WaitForEndOfFrame();
         /* 
          * Override settings to use the Example game setup
          */

--- a/Samples~/LootLockerExamples/6a - Simple Progression/LootLockerLevelProgression.cs
+++ b/Samples~/LootLockerExamples/6a - Simple Progression/LootLockerLevelProgression.cs
@@ -24,6 +24,13 @@ namespace LootLocker
         // Start is called before the first frame update
         void Start()
         {
+            StartCoroutine(DoLoginAndSetUp());
+        }
+
+        IEnumerator DoLoginAndSetUp()
+        {
+            // Wait until end of frame to ensure that the UI has been loaded
+            yield return new WaitForEndOfFrame();
             /* 
             * Override settings to use the Example game setup
             */

--- a/Samples~/LootLockerExamples/6b - Multiple Progressions/LootLockerMultipleProgressions.cs
+++ b/Samples~/LootLockerExamples/6b - Multiple Progressions/LootLockerMultipleProgressions.cs
@@ -45,6 +45,13 @@ namespace LootLocker
         // Start is called before the first frame update
         void Start()
         {
+            StartCoroutine(DoLoginAndSetUp());
+        }
+
+        IEnumerator DoLoginAndSetUp()
+        {
+            // Wait until end of frame to ensure that the UI has been loaded
+            yield return new WaitForEndOfFrame();
             /* 
             * Override settings to use the Example game setup
             */

--- a/Samples~/LootLockerExamples/7 - PlayerFiles/PlayerFiles.cs
+++ b/Samples~/LootLockerExamples/7 - PlayerFiles/PlayerFiles.cs
@@ -25,6 +25,13 @@ namespace LootLocker
         // Start is called before the first frame update
         void Start()
         {
+            StartCoroutine(DoLoginAndSetUp());
+        }
+
+        IEnumerator DoLoginAndSetUp()
+        {
+            // Wait until end of frame to ensure that the UI has been loaded
+            yield return new WaitForEndOfFrame();
             /* 
             * Override settings to use the Example game setup
             */


### PR DESCRIPTION
In CI it happens frequently that ui references aren't initialized when being accessed which throws a null reference exception. So we simply guard against that.