### PR TITLE
Fix/catalog asset listings

### DIFF
--- a/Runtime/Game/Requests/CatalogRequests.cs
+++ b/Runtime/Game/Requests/CatalogRequests.cs
@@ -160,12 +160,16 @@ namespace LootLocker.Requests
 
         public override int GetHashCode()
         {
-            return catalog_listing_id.GetHashCode() + item_id.GetHashCode();
+            return catalog_listing_id?.GetHashCode() ?? 0;
         }
 
         public override bool Equals(object obj)
         {
-            return obj.GetHashCode() == GetHashCode();
+            if (obj is LootLockerItemDetailsKey other)
+            {
+                return this.catalog_listing_id == other.catalog_listing_id;
+            }
+            return false;
         }
 
     }

--- a/Runtime/Game/Requests/CatalogRequests.cs
+++ b/Runtime/Game/Requests/CatalogRequests.cs
@@ -160,7 +160,7 @@ namespace LootLocker.Requests
 
         public override int GetHashCode()
         {
-            return catalog_listing_id?.GetHashCode() ?? 0;
+            return catalog_listing_id.GetHashCode() + item_id.GetHashCode();
         }
 
         public override bool Equals(object obj)
@@ -717,25 +717,25 @@ namespace LootLocker.Requests
                             switch (association.kind)
                             {
                                 case LootLockerCatalogEntryEntityKind.asset:
-                                    if (catalogListing.asset_details.ContainsKey(entry.GetItemDetailsKey()))
+                                    if (catalogListing.asset_details.ContainsKey(association.GetItemDetailsKey()))
                                     {
                                         inlinedGroupDetails.assetDetails.Add(catalogListing.asset_details[association.GetItemDetailsKey()]);
                                     }
                                     break;
                                 case LootLockerCatalogEntryEntityKind.progression_points:
-                                    if (catalogListing.progression_points_details.ContainsKey(entry.GetItemDetailsKey()))
+                                    if (catalogListing.progression_points_details.ContainsKey(association.GetItemDetailsKey()))
                                     {
                                         inlinedGroupDetails.progressionPointDetails.Add(catalogListing.progression_points_details[association.GetItemDetailsKey()]);
                                     }
                                     break;
                                 case LootLockerCatalogEntryEntityKind.progression_reset:
-                                    if (catalogListing.progression_resets_details.ContainsKey(entry.GetItemDetailsKey()))
+                                    if (catalogListing.progression_resets_details.ContainsKey(association.GetItemDetailsKey()))
                                     {
                                         inlinedGroupDetails.progressionResetDetails.Add(catalogListing.progression_resets_details[association.GetItemDetailsKey()]);
                                     }
                                     break;
                                 case LootLockerCatalogEntryEntityKind.currency:
-                                    if (catalogListing.currency_details.ContainsKey(entry.GetItemDetailsKey()))
+                                    if (catalogListing.currency_details.ContainsKey(association.GetItemDetailsKey()))
                                     {
                                         inlinedGroupDetails.currencyDetails.Add(catalogListing.currency_details[association.GetItemDetailsKey()]);
                                     }

--- a/Runtime/Game/Requests/CatalogRequests.cs
+++ b/Runtime/Game/Requests/CatalogRequests.cs
@@ -160,7 +160,7 @@ namespace LootLocker.Requests
 
         public override int GetHashCode()
         {
-            return catalog_listing_id.GetHashCode() + item_id.GetHashCode();
+            return catalog_listing_id?.GetHashCode() ?? 0;
         }
 
         public override bool Equals(object obj)

--- a/Runtime/Game/Requests/CatalogRequests.cs
+++ b/Runtime/Game/Requests/CatalogRequests.cs
@@ -160,16 +160,12 @@ namespace LootLocker.Requests
 
         public override int GetHashCode()
         {
-            return catalog_listing_id?.GetHashCode() ?? 0;
+            return catalog_listing_id.GetHashCode() + item_id.GetHashCode();
         }
 
         public override bool Equals(object obj)
         {
-            if (obj is LootLockerItemDetailsKey other)
-            {
-                return this.catalog_listing_id == other.catalog_listing_id;
-            }
-            return false;
+            return obj.GetHashCode() == GetHashCode();
         }
 
     }


### PR DESCRIPTION
- Proper fix added
- New PR that points to dev instead of main

Old PR description:
Previously, both catalog_listing_id and item_id was used to generate the hash to compare what would be added to the list, however the item_id is not the same for the two different entries so nothing was ever added to the list.
This fixes that.