### PR TITLE
fix: Sanitize SDK error messages to remove LootLocker-specific wording

### DIFF
--- a/Runtime/Client/LootLockerErrorData.cs
+++ b/Runtime/Client/LootLockerErrorData.cs
@@ -54,17 +54,17 @@
             // Empty error, make sure we print something
             if (string.IsNullOrEmpty(message) && string.IsNullOrEmpty(trace_id) && string.IsNullOrEmpty(request_id))
             {
-                return $"An unexpected LootLocker error without error data occurred. Please try again later.\n If the issue persists, please contact LootLocker support.";
+                return $"An unexpected error occurred. Please try again later. If the issue persists, please contact support.";
             }
 
             //Print the most important info first
-            string prettyError = $"LootLocker Error: \"{message ?? ""}\"";
+            string prettyError = $"Error: \"{message ?? ""}\"";
 
             // Look for intermittent, non user errors
             if (!string.IsNullOrEmpty(code) && code.StartsWith("HTTP5"))
             {
                 prettyError +=
-                    $"\nTry again later. If the issue persists, please contact LootLocker support and provide the following error details:\n trace ID - \"{trace_id ?? ""}\",\n request ID - \"{request_id ?? ""}\",\n message - \"{message ?? ""}\".";
+                    $"\nTry again later. If the issue persists, please contact support and provide the following error details:\n trace ID - \"{trace_id ?? ""}\",\n request ID - \"{request_id ?? ""}\",\n message - \"{message ?? ""}\".";
                 if (!string.IsNullOrEmpty(doc_url))
                 {
                     prettyError += $"\nFor more information, see {doc_url} (error code was \"{code}\").";
@@ -81,7 +81,7 @@
                 }
 
                 prettyError +=
-                    $"\nIf you are unable to fix the issue, contact LootLocker support and provide the following error details:";
+                    $"\nIf you are unable to fix the issue, contact support and provide the following error details:";
                 if (!string.IsNullOrEmpty(trace_id ?? ""))
                 {
                     prettyError += $"\n     trace ID - \"{trace_id}\"";

--- a/Runtime/Client/LootLockerEventSystem.cs
+++ b/Runtime/Client/LootLockerEventSystem.cs
@@ -180,7 +180,7 @@ namespace LootLocker
     [Serializable]
     public class LootLockerEventSystemResetEventData : LootLockerEventData
     {
-        string message { get; set; } = "The LootLocker Event System has been reset and all subscribers have been cleared. If you were subscribed to events, you will need to re-subscribe.";
+        string message { get; set; } = "The event system has been reset and all subscribers have been cleared. If you were subscribed to events, you will need to re-subscribe.";
         public LootLockerEventSystemResetEventData() 
             : base(LootLockerEventType.EventSystemReset)
         {

--- a/Runtime/Client/LootLockerPresenceManager.cs
+++ b/Runtime/Client/LootLockerPresenceManager.cs
@@ -607,7 +607,7 @@ namespace LootLocker
 
             if (!instance._isEnabled)
             {
-                    string errorMessage = "Presence is disabled. Enable it in Project Settings > LootLocker SDK > Presence Settings or use _SetPresenceEnabled(true).";
+                    string errorMessage = "Presence is disabled. Enable it in the SDK settings or use _SetPresenceEnabled(true).";
                 LootLockerLogger.Log(errorMessage, LootLockerLogger.LogLevel.Debug);
                 onComplete?.Invoke(false, errorMessage);
                 return;

--- a/Runtime/Client/LootLockerResponse.cs
+++ b/Runtime/Client/LootLockerResponse.cs
@@ -207,7 +207,7 @@ namespace LootLocker
         /// </summary>
         public static T SDKNotInitializedError<T>(string forPlayerWithUlid, DateTime? requestTime = null, string requestId = null) where T : LootLockerResponse, new()
         {
-            return ClientError<T>("The LootLocker SDK has not been initialized, please start a session to call this method", forPlayerWithUlid, requestTime, requestId);
+            return ClientError<T>("The game client has not been initialized, please start a session to call this method", forPlayerWithUlid, requestTime, requestId);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Addresses https://github.com/lootlocker/index/issues/1438 (duplicate: https://github.com/lootlocker/index/issues/1392).

Customers sometimes show SDK error messages directly to end users, who are unaware of LootLocker as a middleware provider. This PR replaces LootLocker-branded strings in user-surfaced error messages with neutral, end-user-friendly wording.

## Changes

| File | Change |
|------|--------|
| `Runtime/Client/LootLockerErrorData.cs` | Remove `"LootLocker Error:"` prefix from error output; replace `"LootLocker support"` with `"support"`; improve empty-error fallback text |
| `Runtime/Client/LootLockerResponse.cs` | `SDKNotInitializedError`: replace `"The LootLocker SDK has not been initialized"` with `"The game client has not been initialized"` |
| `Runtime/Client/LootLockerEventSystem.cs` | Remove `"LootLocker"` from event-system reset message |
| `Runtime/Client/LootLockerPresenceManager.cs` | Remove `"LootLocker SDK"` from presence-disabled message |