### PR TITLE
fix: Make SDK asset loading path-agnostic for any install location

### DIFF
--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.UI.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.UI.cs
@@ -36,10 +36,18 @@ namespace LootLocker.Extension
             }
             if (visualTree == null)
             {
-                // Find by asset name in the AssetDatabase — works for any install location
+                // Find by exact filename in the AssetDatabase — works for any install location
                 string[] guids = AssetDatabase.FindAssets("LootLockerAdminExtension t:VisualTreeAsset");
-                if (guids.Length > 0)
-                    visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(AssetDatabase.GUIDToAssetPath(guids[0]));
+                foreach (string guid in guids)
+                {
+                    string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                    if (assetPath.EndsWith("/LootLockerAdminExtension.uxml", StringComparison.Ordinal))
+                    {
+                        visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(assetPath);
+                        if (visualTree != null)
+                            break;
+                    }
+                }
             }
             if (visualTree == null)
             {

--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.UI.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.UI.cs
@@ -41,7 +41,7 @@ namespace LootLocker.Extension
                 foreach (string guid in guids)
                 {
                     string assetPath = AssetDatabase.GUIDToAssetPath(guid);
-                    if (assetPath.EndsWith("/LootLockerAdminExtension.uxml", StringComparison.Ordinal))
+                    if (assetPath.EndsWith("/LootLockerAdminExtension.uxml", System.StringComparison.Ordinal))
                     {
                         visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(assetPath);
                         if (visualTree != null)

--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.UI.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.UI.cs
@@ -36,7 +36,14 @@ namespace LootLocker.Extension
             }
             if (visualTree == null)
             {
-                Debug.LogError("LootLockerAdminExtension: LootLocker not found in `Assets/LootLocker` or in Packages. Non standard install locations not supported.");
+                // Find by asset name in the AssetDatabase — works for any install location
+                string[] guids = AssetDatabase.FindAssets("LootLockerAdminExtension t:VisualTreeAsset");
+                if (guids.Length > 0)
+                    visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(AssetDatabase.GUIDToAssetPath(guids[0]));
+            }
+            if (visualTree == null)
+            {
+                Debug.LogError("LootLockerAdminExtension: Could not find LootLockerAdminExtension.uxml in the AssetDatabase.");
                 return;
             }
 

--- a/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
+++ b/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
@@ -40,10 +40,18 @@ namespace LootLocker.Extension
             }
             if (visualTree == null)
             {
-                // Find by asset name in the AssetDatabase — works for any install location
+                // Find by exact filename in the AssetDatabase — works for any install location
                 string[] guids = AssetDatabase.FindAssets("LootLockerLogViewerWindow t:VisualTreeAsset");
-                if (guids.Length > 0)
-                    visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(AssetDatabase.GUIDToAssetPath(guids[0]));
+                foreach (string guid in guids)
+                {
+                    string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                    if (assetPath.EndsWith("/LootLockerLogViewerWindow.uxml", StringComparison.Ordinal))
+                    {
+                        visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(assetPath);
+                        if (visualTree != null)
+                            break;
+                    }
+                }
             }
             if (visualTree == null)
             {

--- a/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
+++ b/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
@@ -40,7 +40,14 @@ namespace LootLocker.Extension
             }
             if (visualTree == null)
             {
-                Debug.LogError("LootLockerLogViewerWindow: LootLocker not found in `Assets/LootLocker` or in Packages. Non standard install locations not supported.");
+                // Find by asset name in the AssetDatabase — works for any install location
+                string[] guids = AssetDatabase.FindAssets("LootLockerLogViewerWindow t:VisualTreeAsset");
+                if (guids.Length > 0)
+                    visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(AssetDatabase.GUIDToAssetPath(guids[0]));
+            }
+            if (visualTree == null)
+            {
+                Debug.LogError("LootLockerLogViewerWindow: Could not find LootLockerLogViewerWindow.uxml in the AssetDatabase.");
                 return;
             }
             var root = rootVisualElement;

--- a/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
+++ b/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
@@ -45,7 +45,7 @@ namespace LootLocker.Extension
                 foreach (string guid in guids)
                 {
                     string assetPath = AssetDatabase.GUIDToAssetPath(guid);
-                    if (assetPath.EndsWith("/LootLockerLogViewerWindow.uxml", StringComparison.Ordinal))
+                    if (assetPath.EndsWith("/LootLockerLogViewerWindow.uxml", System.StringComparison.Ordinal))
                     {
                         visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(assetPath);
                         if (visualTree != null)

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -18,12 +18,58 @@ namespace LootLocker
         private static readonly string SettingsName = $"{PackageName}Config";
         private static readonly string ConfigFolderName = $"{PackageName}SDK";
         private static readonly string ConfigAssetName = $"{SettingsName}.asset";
-        private static readonly string ConfigAssetsPath = $"Assets/{ConfigFolderName}/Resources/Config/{ConfigAssetName}";
-        private static string ConfigResourceFolder => $"{Application.dataPath}/{ConfigFolderName}/Resources/Config";
         private static readonly string ConfigFileIdentifier = ""; // Optional extra package id if you want to be able to switch between multiple configurations
         private static readonly string ConfigFileExtension = ".bytes";
         private static readonly string ConfigFileName = $"{SettingsName}" + (string.IsNullOrEmpty(ConfigFileIdentifier) ? "" : $"-{ConfigFileIdentifier}");
-        private static readonly string ConfigFilePath = $"Assets/{ConfigFolderName}/Resources/Config/{ConfigFileName}{ConfigFileExtension}";
+
+#if UNITY_EDITOR
+        private static string _cachedSdkRootPath = null;
+
+        // Locates the SDK root by finding this script in the AssetDatabase and walking up four
+        // directory levels: LootLockerConfig.cs -> Resources/ -> Game/ -> Runtime/ -> SDK root.
+        // This works regardless of install location (Assets/, Packages/, or any custom path).
+        private static string GetSdkRootAssetsPath(bool requireWritable = false)
+        {
+            if (_cachedSdkRootPath == null)
+            {
+                string[] guids = AssetDatabase.FindAssets($"{nameof(LootLockerConfig)} t:MonoScript");
+                foreach (string guid in guids)
+                {
+                    string scriptPath = AssetDatabase.GUIDToAssetPath(guid);
+                    if (scriptPath.EndsWith($"/{nameof(LootLockerConfig)}.cs", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Walk up 4 levels: Resources/ -> Game/ -> Runtime/ -> SDK root
+                        string dir = Path.GetDirectoryName(scriptPath); // .../Resources
+                        dir = Path.GetDirectoryName(dir);               // .../Game
+                        dir = Path.GetDirectoryName(dir);               // .../Runtime
+                        dir = Path.GetDirectoryName(dir);               // SDK root
+                        if (!string.IsNullOrEmpty(dir))
+                        {
+                            _cachedSdkRootPath = dir.Replace('\\', '/');
+                            break;
+                        }
+                    }
+                }
+                if (string.IsNullOrEmpty(_cachedSdkRootPath))
+                    _cachedSdkRootPath = $"Assets/{ConfigFolderName}";
+            }
+            // Packages/ is read-only — writable content (e.g. asset creation) must go under Assets/
+            if (requireWritable && _cachedSdkRootPath.StartsWith("Packages/", StringComparison.OrdinalIgnoreCase))
+                return $"Assets/{ConfigFolderName}";
+            return _cachedSdkRootPath;
+        }
+
+        private static string ConfigAssetsPath => $"{GetSdkRootAssetsPath(requireWritable: true)}/Resources/Config/{ConfigAssetName}";
+        private static string ConfigResourceFolder
+        {
+            get
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                return Path.Combine(projectRoot, GetSdkRootAssetsPath(requireWritable: true), "Resources", "Config");
+            }
+        }
+        private static string ConfigFilePath => $"{GetSdkRootAssetsPath()}/Resources/Config/{ConfigFileName}{ConfigFileExtension}";
+#endif
 
 
 #region User Config Variables
@@ -118,32 +164,59 @@ namespace LootLocker
         private static ExternalFileConfig CheckForFileConfig()
         {
             ExternalFileConfig fileConfig = null;
-            try {
-                if(!File.Exists(ConfigFilePath))
-                {
-                    return fileConfig;
-                }
-#if UNITY_EDITOR
-                AssetDatabase.ImportAsset(ConfigFilePath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
-                AssetDatabase.Refresh();
-                TextAsset configTextAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(ConfigFilePath);
-#else
-                TextAsset configTextAsset = null;
-#endif
-                
-                // Fallback: if Unity asset system isn't ready, read file directly from disk
+            try
+            {
                 string configText = null;
-                if(configTextAsset != null)
+
+                // 1. Primary: Resources.Load — works in any install location in both editor and builds.
+                //    The .bytes file must be inside a Resources/ folder for this to work.
+                TextAsset resourcesTextAsset = Resources.Load<TextAsset>($"Config/{ConfigFileName}");
+                if (resourcesTextAsset != null)
                 {
-                    configText = configTextAsset.text;
+                    configText = resourcesTextAsset.text;
                 }
-                else
+
+#if UNITY_EDITOR
+                // 2. Editor fallback A: search AssetDatabase by name — finds the file regardless of
+                //    where it lives in the project (handles race where Resources DB is not yet warmed up)
+                if (configText == null)
                 {
-                    // Direct file read as fallback
-                    configText = File.ReadAllText(ConfigFilePath);
+                    string[] guids = AssetDatabase.FindAssets($"{ConfigFileName} t:TextAsset");
+                    foreach (string guid in guids)
+                    {
+                        string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                        if (Path.GetFileNameWithoutExtension(assetPath).Equals(ConfigFileName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            TextAsset foundAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(assetPath);
+                            if (foundAsset != null)
+                            {
+                                configText = foundAsset.text;
+                                break;
+                            }
+                        }
+                    }
                 }
-                
-                if(!string.IsNullOrEmpty(configText))
+
+                // 3. Editor fallback B: SDK-root-relative path with forced re-import; also reads
+                //    the file directly from disk if the asset database still hasn't picked it up
+                if (configText == null && File.Exists(ConfigFilePath))
+                {
+                    AssetDatabase.ImportAsset(ConfigFilePath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    AssetDatabase.Refresh();
+                    TextAsset configTextAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(ConfigFilePath);
+                    if (configTextAsset != null)
+                    {
+                        configText = configTextAsset.text;
+                    }
+                    else
+                    {
+                        // Direct file read as last resort when the asset database is still not ready
+                        configText = File.ReadAllText(ConfigFilePath);
+                    }
+                }
+#endif
+
+                if (!string.IsNullOrEmpty(configText))
                 {
                     var encryptedBase64 = configText;
                     if (!LootLocker.Utilities.Encryption.LootLockerEncryptionUtilities.IsValidBase64String(encryptedBase64))
@@ -162,16 +235,13 @@ namespace LootLocker
                         return fileConfig;
                     }
                 }
-                else
-                {
-                }
             }
             catch (Exception ex)
             {
                 LootLockerLogger.Log("Error while checking for file config: " + ex.Message, LootLockerLogger.LogLevel.Error);
                 return fileConfig;
             }
-            return fileConfig;            
+            return fileConfig;
         }
 
 #if UNITY_EDITOR
@@ -344,7 +414,7 @@ namespace LootLocker
         {
             if ((!string.IsNullOrEmpty(LootLockerConfig.current.sdk_version) && !LootLockerConfig.current.sdk_version.Equals("N/A")) 
                 || ListInstalledPackagesRequest != null
-                || File.Exists(ConfigFilePath) /*Configured through config file, read sdk version there*/)
+                || AssetDatabase.FindAssets($"{ConfigFileName} t:TextAsset").Length > 0 /*Configured through config file, read sdk version there*/)
             {
                 return;
             }
@@ -374,9 +444,10 @@ namespace LootLocker
                     }
                 }
 
-                if (File.Exists("Assets/LootLockerSDK/package.json"))
+                string sdkPackageJsonPath = $"{GetSdkRootAssetsPath()}/package.json";
+                if (File.Exists(sdkPackageJsonPath))
                 {
-                    LootLockerConfig.current.sdk_version = LootLockerJson.DeserializeObject<LLPackageDescription>(File.ReadAllText("Assets/LootLockerSDK/package.json")).version;
+                    LootLockerConfig.current.sdk_version = LootLockerJson.DeserializeObject<LLPackageDescription>(File.ReadAllText(sdkPackageJsonPath)).version;
                     LootLockerLogger.Log($"SDK Version v{LootLockerConfig.current.sdk_version}", LootLockerLogger.LogLevel.Verbose);
                     return;
                 }
@@ -575,6 +646,7 @@ namespace LootLocker
         static void OnEnterPlaymodeInEditor(EnterPlayModeOptions options)
         {
             _current = null;
+            _cachedSdkRootPath = null;
         }
 #endif
 #endregion

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -28,6 +28,7 @@ namespace LootLocker
         // Locates the SDK root by finding this script in the AssetDatabase and walking up four
         // directory levels: LootLockerConfig.cs -> Resources/ -> Game/ -> Runtime/ -> SDK root.
         // This works regardless of install location (Assets/, Packages/, or any custom path).
+        // But it only works in the editor
         private static string GetSdkRootAssetsPath(bool requireWritable = false)
         {
             if (_cachedSdkRootPath == null)
@@ -185,7 +186,9 @@ namespace LootLocker
                     foreach (string guid in guids)
                     {
                         string assetPath = AssetDatabase.GUIDToAssetPath(guid);
-                        if (Path.GetFileNameWithoutExtension(assetPath).Equals(ConfigFileName, StringComparison.OrdinalIgnoreCase))
+                        // Match exact filename including extension to avoid false positives from
+                        // other TextAssets (e.g. .json/.txt) that share the same base name
+                        if (assetPath.EndsWith($"/{ConfigFileName}{ConfigFileExtension}", StringComparison.OrdinalIgnoreCase))
                         {
                             TextAsset foundAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(assetPath);
                             if (foundAsset != null)
@@ -414,7 +417,8 @@ namespace LootLocker
         {
             if ((!string.IsNullOrEmpty(LootLockerConfig.current.sdk_version) && !LootLockerConfig.current.sdk_version.Equals("N/A")) 
                 || ListInstalledPackagesRequest != null
-                || AssetDatabase.FindAssets($"{ConfigFileName} t:TextAsset").Length > 0 /*Configured through config file, read sdk version there*/)
+                || Array.Exists(AssetDatabase.FindAssets($"{ConfigFileName} t:TextAsset"),
+                    g => AssetDatabase.GUIDToAssetPath(g).EndsWith($"/{ConfigFileName}{ConfigFileExtension}", StringComparison.OrdinalIgnoreCase)) /*Configured through config file, read sdk version there*/)
             {
                 return;
             }


### PR DESCRIPTION
## Tracking issue

Closes lootlocker/index#1412

## Description

Previously, `LootLockerConfig.cs` used hardcoded paths rooted at `Assets/LootLockerSDK/`, which broke the file-based configuration system (`LootLockerConfig.bytes`) when the SDK was installed anywhere other than that exact location — for example when delivered as part of a publisher package or placed in a custom folder.

**`LootLockerConfig.cs`**
- Added `GetSdkRootAssetsPath()` — locates the SDK root at runtime by finding `LootLockerConfig.cs` in the `AssetDatabase` via `FindAssets` and walking up four directory levels. Cached for performance; cache is cleared on play mode entry. For Package Manager installs (`Packages/` is read-only) the helper automatically redirects writable paths (asset creation) to `Assets/LootLockerSDK/`.
- `ConfigAssetsPath`, `ConfigResourceFolder`, and `ConfigFilePath` are now dynamic `#if UNITY_EDITOR` properties using that helper instead of hardcoded `readonly` strings.
- `CheckForFileConfig()` now uses a three-tier fallback chain:
  1. `Resources.Load<TextAsset>` — works in builds and editor, no path knowledge needed
  2. `AssetDatabase.FindAssets` by name — editor only, covers the race window where the Resources database is not yet warmed up after installation
  3. `GetSdkRootAssetsPath()`-relative `File.Exists` + forced `AssetDatabase` reimport — last resort for files outside a `Resources/` folder
- `StoreSDKVersion()`: replaced `File.Exists(ConfigFilePath)` guard with `AssetDatabase.FindAssets` so it works path-agnostically.
- `ListInstalledPackagesRequestProgress()`: replaced hardcoded `Assets/LootLockerSDK/package.json` with `GetSdkRootAssetsPath()`.

**`LootLockerLogViewerWindow.cs` and `LootLockerAdminExtension.UI.cs`**
- Added an `AssetDatabase.FindAssets t:VisualTreeAsset` fallback before the final `Debug.LogError`, covering UXML discovery for custom install paths.

## Type of change

- [x] Bug fix

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Branch follows naming convention (`fix/`)
- [x] Diff is minimal and scoped — no unrelated changes, no drive-by refactors
- [x] No version bumps or release metadata changes
- [x] No new helpers/utilities introduced without first searching for existing ones
- [x] Runtime code has no unguarded `UnityEditor` dependencies (`GetSdkRootAssetsPath` and all three changed path fields are inside `#if UNITY_EDITOR`)
- [x] Editor-only code is placed under `Runtime/Editor/` and/or guarded with `#if UNITY_EDITOR`
- [x] Tracking issue in `lootlocker/index` is linked and status set to "In Review"

## Testing notes

> ⚠️ **This change requires thorough manual testing across all three install variations before merging.** Automated CI only covers compilation, not runtime path resolution.

### Install variations to test

Set up three separate Unity projects:

| Project | Install method | SDK location |
|---------|---------------|--------------|
| **A** | UPM / Package Manager | `Packages/com.lootlocker.lootlockersdk/` |
| **B** | Standard `.unitypackage` | `Assets/LootLockerSDK/` |
| **C** | Custom location | e.g. `Assets/ThirdParty/Pantaloon/LootLocker/` |

For project C, physically move the SDK folder and update `.asmdef` references so it compiles.

### 1. SDK root discovery

In each project, verify `GetSdkRootAssetsPath()` returns the correct root. Expected:
- A: `Packages/com.lootlocker.lootlockersdk`
- B: `Assets/LootLockerSDK`
- C: the custom path
- A with `requireWritable: true`: must return an `Assets/` path (Packages/ is read-only)
- After entering/exiting Play Mode: re-resolves correctly (`_cachedSdkRootPath` was cleared)

### 2. First-time install — config asset creation

- Delete any existing `LootLockerConfig.asset`, clear the creation EditorPref, reopen
- Verify the `.asset` is created at the correct path (always under `Assets/` even for project A)

### 3. File config loading — all three fallback paths

**3a. `Resources.Load` (primary):** Place `LootLockerConfig.bytes` in `Resources/Config/`, enter Play Mode immediately. Verify config loads with the correct `api_key`. Also verify in a **build**.

**3b. `AssetDatabase.FindAssets` by name:** Temporarily rename the file to exclude it from a `Resources/` folder so `Resources.Load` returns null, verify fallback B picks it up.

**3c. File.Exists + forced reimport:** Place the file outside any `Resources/` folder; verify fallbacks A and B miss it and fallback C finds it.

**3d. No file present:** Remove all `.bytes` files; verify `Get()` returns the `.asset` config without crash or error.

### 4. File config content variations

| Content | Expected |
|---------|----------|
| Plaintext JSON | Parsed directly |
| Valid Base64-encrypted JSON | Decrypted and parsed |
| Invalid Base64 | Treated as plaintext; if unparseable → `null`, no crash |
| Empty file | Returns `null`, no crash |
| Malformed JSON | Returns `null`, no crash |
| Valid JSON, missing `api_key` | Returns `null` |

### 5. SDK version detection

- **Project A (UPM):** version resolved via package enumeration callback
- **Projects B/C:** falls through to dynamic `sdkPackageJsonPath` check, reads `package.json` at the correct root
- **Config file present:** `StoreSDKVersion` early-returns, no `ListInstalledPackagesRequest` launched

### 6. Play Mode entry / domain reload

Verify `GetSdkRootAssetsPath()` is re-executed after each play mode entry (cache cleared) and resolves to the same correct value.

### 7. Editor windows — UXML loading

For each of the three install projects, open **Window > LootLocker > Log Viewer** and the **Admin Extension** window. Verify they render without `Debug.LogError`. For project C, confirm it is the `AssetDatabase.FindAssets` fallback that succeeds (the three hardcoded `EditorGUIUtility.Load` calls will all return null).

### 8. Build regression (Runtime path, no `AssetDatabase`)

- Build with a `.bytes` file in `Resources/Config/` → verify config loads from it
- Build without the file → verify `.asset` config used, no crash
- Build without any config at all → verify `ArgumentException` thrown with correct message

### Existing behaviour regression checklist

- [ ] Config Inspector window saves/loads correctly
- [ ] `CreateNewSettings(string apiKey, ...)` overrides at runtime
- [ ] `ClearSettings()` clears all fields
- [ ] `-apikey` / `-domainkey` command-line overrides work (with `LOOTLOCKER_COMMANDLINE_SETTINGS`)
- [ ] `ValidateSettings()` rejects missing API key

## Additional notes

The three-tier fallback in `CheckForFileConfig()` preserves all existing behaviour and adds coverage for the custom-path scenario. There is no behavioural change for standard installs (projects A and B).
