### PR TITLE
feat(error-report): add dedicated error report endpoint

### DIFF
--- a/Runtime/Client/LootLockerEndPoints.cs
+++ b/Runtime/Client/LootLockerEndPoints.cs
@@ -294,6 +294,10 @@ namespace LootLocker
         public static EndPointClass listFeedbackCategories = new EndPointClass("feedback/category/entity/{0}", LootLockerHTTPMethod.GET);
         public static EndPointClass createFeedbackEntry = new EndPointClass("feedback", LootLockerHTTPMethod.POST);
 
+        // Error Reports
+        [Header("Error Reports")]
+        public static EndPointClass createErrorReport = new EndPointClass("error-report", LootLockerHTTPMethod.POST);
+
         // Friends
         [Header("Friends")]
         public static EndPointClass listFriends = new EndPointClass("player/friends", LootLockerHTTPMethod.GET);

--- a/Runtime/Client/LootLockerErrorReportBody.cs
+++ b/Runtime/Client/LootLockerErrorReportBody.cs
@@ -1,0 +1,84 @@
+using System;
+using LootLocker.Requests;
+
+namespace LootLocker.Requests
+{
+    /// <summary>
+    /// Internal DTO mapping LootLockerFailedRequestReport to snake_case field names for the error-report API.
+    /// </summary>
+    class LootLockerErrorReportBody
+    {
+        /// <summary>
+        /// A description of the error provided by the user, useful for debugging and support. Optional but recommended when submitting error reports to help with troubleshooting.
+        /// </summary>
+        public string user_description { get; set; }
+        /// <summary>
+        /// The id of the request on the client side
+        /// </summary>
+        public string client_request_id { get; set; }
+        /// <summary>
+        /// The id of the request on the server side
+        /// </summary>
+        public string server_request_id { get; set; }
+        /// <summary>
+        /// The id of the trace on the server side, useful for debugging with support
+        /// </summary>
+        public string trace_id { get; set; }
+        /// <summary>
+        /// The status code of the response
+        /// </summary>
+        public int status_code { get; set; }
+        /// <summary>
+        /// The error message provided by the server
+        /// </summary>
+        public string message { get; set; }
+        /// <summary>
+        /// The endpoint that was called
+        /// </summary>
+        public string endpoint { get; set; }
+        /// <summary>
+        /// The HTTP method used for the request (e.g. GET, POST, etc.)
+        /// </summary>
+        public string http_method { get; set; }
+        /// <summary>
+        /// The body of the response
+        /// </summary>
+        public string response_body { get; set; }
+        /// <summary>
+        /// The headers of the response
+        /// </summary>
+        public string[] response_headers { get; set; }
+        /// <summary>
+        /// The body of the request
+        /// </summary>
+        public string request_body { get; set; }
+        /// <summary>
+        /// The headers of the request
+        /// </summary>
+        public string[] request_headers { get; set; }
+        /// <summary>
+        /// The number of times this request was retried
+        /// </summary>
+        public int retry_attempts { get; set; }
+        /// <summary>
+        /// The duration of the request's round trip in seconds
+        /// </summary>
+        public float request_duration_seconds { get; set; }
+        /// <summary>
+        /// The timestamp of when the error occurred on the server
+        /// </summary>
+        public string server_timestamp { get; set; }
+        /// <summary>
+        /// The timestamp of when the error occurred on the client
+        /// </summary>
+        public string client_timestamp { get; set; }
+        /// <summary>
+        /// The player's ULID
+        /// </summary>
+        public string player_ulid { get; set; }
+        /// <summary>
+        /// The version of the LootLocker SDK used
+        /// </summary>
+        public string sdk_version { get; set; }
+    }
+}

--- a/Runtime/Client/LootLockerErrorReportBody.cs
+++ b/Runtime/Client/LootLockerErrorReportBody.cs
@@ -1,6 +1,3 @@
-using System;
-using LootLocker.Requests;
-
 namespace LootLocker.Requests
 {
     /// <summary>

--- a/Runtime/Client/LootLockerErrorReportBody.cs.meta
+++ b/Runtime/Client/LootLockerErrorReportBody.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7dc484826ec5d954daa5918f810206e0

--- a/Runtime/Client/LootLockerHTTPClient.cs
+++ b/Runtime/Client/LootLockerHTTPClient.cs
@@ -171,13 +171,6 @@ namespace LootLocker
                 IsInitialized = true;
                 _instance = this;
 
-                if (!string.IsNullOrEmpty(LootLockerStateData.GetDefaultPlayerULID()))
-                {
-                    if(LootLockerFailureFeedbackCategory.Equals("Not Initialized"))
-                    {
-                        RefreshFailureFeedbackCategoryId((_ignored) => {});                  
-                    }
-                }
             }
             LootLockerLogger.Log("HTTPClient initialized", LootLockerLogger.LogLevel.Verbose);
         }
@@ -1011,56 +1004,10 @@ namespace LootLocker
             /// The ULID of the player for whom the request was made. This can be useful information for debugging and error analysis, as it can help determine if the failure was specific to a particular player or if it was a more widespread issue. It can also be useful for analyzing patterns of failures across different players.
             /// </summary>
             public string PlayerUlid { get; set; }
-        }
-
-        private static string LootLockerFailureFeedbackCategory = "Not Initialized";
-
-        public bool IsFailureReportingEnabled()
-        {
-            return !string.IsNullOrEmpty(LootLockerFailureFeedbackCategory);
-        }
-
-        public string GetFailureFeedbackCategoryId()
-        {
-            return LootLockerFailureFeedbackCategory;
-        }
-
-        public void RefreshFailureFeedbackCategoryId(Action<bool> value)
-        {
-            if(string.IsNullOrEmpty(LootLockerFailureFeedbackCategory))
-            {
-                value?.Invoke(false);
-                return;
-            }
-            if(LootLockerFailureFeedbackCategory.Equals("Not Initialized"))
-            {
-                LootLockerSDKManager.ListGameFeedbackCategories((feedbackCategoriesResponse) => 
-                {
-                    if(!feedbackCategoriesResponse.success)
-                    {
-                        LootLockerLogger.Log($"Failed to retrieve feedback categories for error report. Status code: {feedbackCategoriesResponse.statusCode} and message: {feedbackCategoriesResponse.errorData.message}", LootLockerLogger.LogLevel.Debug);
-                        LootLockerFailureFeedbackCategory = null;
-                        value?.Invoke(false);
-                        return;
-                    }
-                    foreach(var cat in feedbackCategoriesResponse.categories)
-                    {
-                        if(cat?.name == "lootlocker_request_failure")
-                        {
-                            LootLockerFailureFeedbackCategory = cat.id;
-                            value?.Invoke(true);
-                            return;
-                        }
-                    }
-                    LootLockerFailureFeedbackCategory = null;
-                    LootLockerLogger.Log($"Failed to find appropriate category to send error report under. Feedback categories retrieved successfully but no category with name 'lootlocker_request_failure' was found. LootLocker Error reporting turned off", LootLockerLogger.LogLevel.Debug);
-                    value?.Invoke(false);
-                }, LootLockerStateData.GetDefaultPlayerULID());
-            }
-            else {
-                // Category is already initialized, just return true
-                value?.Invoke(true);
-            }
+            /// <summary>
+            /// The version of the LootLocker SDK that sent the request.
+            /// </summary>
+            public string SdkVersion { get; set; }
         }
 
         public bool TryGetFailedRequestReportForRequestId(string requestId, out LootLockerFailedRequestReport report)
@@ -1083,11 +1030,6 @@ namespace LootLocker
 
         private void StoreFailedRequestReport(LootLockerResponse failedResponse, LootLockerHTTPExecutionQueueItem executionItem)
         {
-            if(string.IsNullOrEmpty(LootLockerFailureFeedbackCategory))
-            {
-                // Auto reporting is disabled, do not store error report
-                return;
-            }
             if(failedResponse == null || failedResponse.errorData == null)
             {
                 LootLockerLogger.Log($"Failed response or error data was null, cannot construct valid error report. Player ULID: {executionItem.RequestData.ForPlayerWithUlid}", LootLockerLogger.LogLevel.Debug);
@@ -1134,7 +1076,8 @@ namespace LootLocker
                 RequestDurationSeconds = Time.time - executionItem.RequestStartTime,
                 ServerTimestamp = "", // We resolve this below
                 ClientTimestamp = (DateTime.Now - TimeSpan.FromSeconds(Time.time - executionItem.RequestStartTime)).ToString("o"), // ISO 8601 format
-                PlayerUlid = failedResponsePlayerUlid
+                PlayerUlid = failedResponsePlayerUlid,
+                SdkVersion = LootLockerConfig.current?.sdk_version
             };
             
             var requestHeaders = executionItem.RequestData.ExtraHeaders;

--- a/Runtime/Client/LootLockerHTTPClient.cs
+++ b/Runtime/Client/LootLockerHTTPClient.cs
@@ -747,10 +747,12 @@ namespace LootLocker
             
             response.requestContext = new LootLockerRequestContext(executionItem.RequestData.ForPlayerWithUlid, executionItem.RequestData.RequestStartTime, executionItem.RequestData.RequestId);
             
+#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
             if (response != null && !response.success)
             {
                 StoreFailedRequestReport(response, executionItem);
             }
+#endif
 
             CurrentlyOngoingRequests.Remove(executionItem.RequestData.RequestId);
             executionItem.IsWaitingForSessionRefresh = false;

--- a/Runtime/Client/LootLockerResponse.cs
+++ b/Runtime/Client/LootLockerResponse.cs
@@ -46,6 +46,7 @@ namespace LootLocker
         /// </summary>
         public string EventId { get; set; } = Guid.NewGuid().ToString();
 
+#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
         /// <summary>
         /// Sends a report about a failed request to be viewable in the LootLocker dashboard.
         /// This is intended to be used in the case where a request fails and you want to send the details of that failure to LootLocker for debugging and tracking purposes. 
@@ -59,6 +60,7 @@ namespace LootLocker
         {
             LootLocker.Requests.LootLockerSDKManager.SendLootLockerErrorReport(userDescription, this, onComplete);
         }
+#endif
 
         public static void Deserialize<T>(Action<T> onComplete, LootLockerResponse serverResponse,
 #if LOOTLOCKER_USE_NEWTONSOFTJSON

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -8317,7 +8317,7 @@ namespace LootLocker.Requests
 
             report.UserDescription = userDescription;
 
-            static string[] RedactSensitiveHeaders(string[] headers)
+            string[] RedactSensitiveHeaders(string[] headers)
             {
                 if (headers == null) return null;
                 return headers.Select(h =>

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -8250,6 +8250,7 @@ namespace LootLocker.Requests
             SendFeedback(LootLockerFeedbackTypes.ugc, ulid, description, category_id, onComplete, forPlayerWithUlid);
         }
 
+#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
         /// <summary>
         /// Sends a report about a failed request to be viewable in the LootLocker dashboard.
         /// This is intended to be used in the case where a request fails and you want to send the details of that failure to LootLocker for debugging and tracking purposes. 
@@ -8357,6 +8358,7 @@ namespace LootLocker.Requests
             EndPointClass endPoint = LootLockerEndPoints.createErrorReport;
             LootLockerServerRequest.CallAPI(failedResponse.requestContext.player_ulid, endPoint.endPoint, endPoint.httpMethod, reportAsJson, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
         }
+#endif
         
         /// <param name="forPlayerWithUlid">Optional : Execute the request for the specified player. If not supplied, the default player will be used.</param>
         private static void SendFeedback(LootLockerFeedbackTypes type, string ulid, string description, string category_id, Action<LootLockerResponse> onComplete, string forPlayerWithUlid = null)

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -8308,11 +8308,6 @@ namespace LootLocker.Requests
                 onComplete?.Invoke(LootLockerResponseFactory.ClientError<LootLockerResponse>("Failed to send error report because HTTP client was not available", failedResponse?.requestContext?.player_ulid));
                 return;
             }
-            if(!httpClient.IsFailureReportingEnabled())
-            {
-                onComplete?.Invoke(LootLockerResponseFactory.ClientError<LootLockerResponse>("Failed to send error report because failure reporting is not enabled", failedResponse?.requestContext?.player_ulid));
-                return;
-            }
             
             if(!httpClient.TryGetFailedRequestReportForRequestId(failedResponse.requestContext.request_id, out var report))
             {
@@ -8321,27 +8316,34 @@ namespace LootLocker.Requests
             }
 
             report.UserDescription = userDescription;
-            string reportAsJson = LootLockerJson.SerializeObject(report);
-            reportAsJson = LootLockerObfuscator.ObfuscateJsonStringForLogging(reportAsJson);
-            reportAsJson = LootLockerJson.PrettifyJsonString(reportAsJson);
 
-            string failureFeedbackCategoryId = httpClient.GetFailureFeedbackCategoryId();
-            if(failureFeedbackCategoryId.Equals("Not Initialized"))
+            var body = new LootLockerErrorReportBody
             {
-                httpClient.RefreshFailureFeedbackCategoryId((bool success) =>
-                {
-                    if(!success)
-                    {
-                        onComplete?.Invoke(LootLockerResponseFactory.ClientError<LootLockerResponse>("Failed to send error report because failure feedback category id could not be retrieved from the server", failedResponse?.requestContext?.player_ulid));
-                        return;
-                    }
-                    SendGameFeedback(reportAsJson, httpClient.GetFailureFeedbackCategoryId(), onComplete, failedResponse.requestContext.player_ulid);
-                });
-                return;
-            }
-            SendGameFeedback(reportAsJson, httpClient.GetFailureFeedbackCategoryId(), onComplete, failedResponse.requestContext.player_ulid);
-        }
+                user_description = report.UserDescription,
+                client_request_id = report.ClientRequestId,
+                server_request_id = report.ServerRequestId,
+                trace_id = report.TraceId,
+                status_code = report.StatusCode,
+                message = report.Message,
+                endpoint = report.Endpoint,
+                http_method = report.http_method,
+                response_body = report.ResponseJsonBody,
+                response_headers = report.ResponseHeaders,
+                request_body = report.RequestBody,
+                request_headers = report.RequestHeaders,
+                retry_attempts = report.RetryAttempts,
+                request_duration_seconds = report.RequestDurationSeconds,
+                server_timestamp = report.ServerTimestamp,
+                client_timestamp = report.ClientTimestamp,
+                player_ulid = report.PlayerUlid,
+                sdk_version = report.SdkVersion
+            };
+            string reportAsJson = LootLockerJson.SerializeObject(body);
 
+            EndPointClass endPoint = LootLockerEndPoints.createErrorReport;
+            LootLockerServerRequest.CallAPI(failedResponse.requestContext.player_ulid, endPoint.endPoint, endPoint.httpMethod, reportAsJson, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
+        }
+        
         /// <param name="forPlayerWithUlid">Optional : Execute the request for the specified player. If not supplied, the default player will be used.</param>
         private static void SendFeedback(LootLockerFeedbackTypes type, string ulid, string description, string category_id, Action<LootLockerResponse> onComplete, string forPlayerWithUlid = null)
         {

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -8317,6 +8317,20 @@ namespace LootLocker.Requests
 
             report.UserDescription = userDescription;
 
+            static string[] RedactSensitiveHeaders(string[] headers)
+            {
+                if (headers == null) return null;
+                return headers.Select(h =>
+                {
+                    int sep = h.IndexOf(':');
+                    if (sep <= 0) return h;
+                    string name = h.Substring(0, sep).ToLowerInvariant();
+                    if (name.Contains("token") || name.Contains("authorization") || name.Contains("cookie"))
+                        return h.Substring(0, sep + 1) + " [REDACTED]";
+                    return h;
+                }).ToArray();
+            }
+
             var body = new LootLockerErrorReportBody
             {
                 user_description = report.UserDescription,
@@ -8328,9 +8342,9 @@ namespace LootLocker.Requests
                 endpoint = report.Endpoint,
                 http_method = report.http_method,
                 response_body = report.ResponseJsonBody,
-                response_headers = report.ResponseHeaders,
+                response_headers = RedactSensitiveHeaders(report.ResponseHeaders),
                 request_body = report.RequestBody,
-                request_headers = report.RequestHeaders,
+                request_headers = RedactSensitiveHeaders(report.RequestHeaders),
                 retry_attempts = report.RetryAttempts,
                 request_duration_seconds = report.RequestDurationSeconds,
                 server_timestamp = report.ServerTimestamp,


### PR DESCRIPTION
## Summary

Adds a dedicated error report endpoint replacing the feedback-system-based MVP (issue lootlocker/index#1480).

## Changes

- **`LootLockerErrorReportBody.cs`** (new): dedicated request/response types for the error report entity
- **`LootLockerEndPoints.cs`**: new `ReportSDKError` endpoint
- **`LootLockerHTTPClient.cs`**: extracted error report logic out of the generic HTTP client
- **`LootLockerSDKManager.cs`**: updated public API to use the new dedicated endpoint

## Related

- go-backend PR: lootlocker/go-backend#631

Closes lootlocker/index#1480