### PR TITLE
feat: add non_refundable field to LootLockerCatalogEntry (#1420)

### DIFF
--- a/Runtime/Game/Requests/CatalogRequests.cs
+++ b/Runtime/Game/Requests/CatalogRequests.cs
@@ -316,6 +316,10 @@ namespace LootLocker.Requests
         /// </summary>
         public bool purchasable { get; set; }
         /// <summary>
+        /// Whether this entry is refundable. If false, purchases of this entry cannot be refunded.
+        /// </summary>
+        public bool non_refundable { get; set; }
+        /// <summary>
         /// Function to help identify details simpler
         /// </summary>
         /// <returns>The identifier for looking up details</returns>


### PR DESCRIPTION
## Summary

Exposes the `non_refundable` boolean field on `LootLockerCatalogEntry`, which the backend already returns in catalog item responses.

## Changes

- `Runtime/Game/Requests/CatalogRequests.cs`: Added `non_refundable` property to `LootLockerCatalogEntry` with XML doc comment

## Related

Closes #1420 (tracked via lootlocker/index#1420)