### PR TITLE
feat(auth): add GetPlayerBanStatus endpoint and ban info in error data

### DIFF
--- a/Runtime/Client/LootLockerEndPoints.cs
+++ b/Runtime/Client/LootLockerEndPoints.cs
@@ -24,6 +24,7 @@ namespace LootLocker
         public static EndPointClass googlePlayGamesRefreshSessionRequest = new EndPointClass("session/google-play-games/v1/login", LootLockerHTTPMethod.POST);
         public static EndPointClass steamSessionRequest = new EndPointClass("session/steam", LootLockerHTTPMethod.POST);
         public static EndPointClass playstationNetworkv3SessionRequest = new EndPointClass("session/psn-v3/v1/login", LootLockerHTTPMethod.POST);
+        public static EndPointClass banStatusRequest = new EndPointClass("session/ban-status", LootLockerHTTPMethod.POST);
 
         // Connected Accounts
         [Header("Connected Accounts")]

--- a/Runtime/Client/LootLockerErrorData.cs
+++ b/Runtime/Client/LootLockerErrorData.cs
@@ -46,6 +46,12 @@
         public int? retry_after_seconds { get; set; } = null;
 
         /// <summary>
+        /// When the error code is <c>player_banned</c>, contains sanitized details about the active ban.
+        /// Null for all other error codes.
+        /// </summary>
+        public LootLockerBanInfo ban { get; set; }
+
+        /// <summary>
         /// An easy way of debugging LootLockerErrorData class, example: Debug.Log(onComplete.errorData);
         /// </summary>
         /// <returns>string used to debug errors</returns>

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -2057,6 +2057,36 @@ namespace LootLocker.Requests
         {
             ClearCacheForPlayer(forPlayerWithUlid);
         }
+
+        /// @ingroup Authentication
+        /// <summary>
+        /// Get the ban status for a player. Use this when a session start fails with error code <c>player_banned</c>
+        /// to retrieve the ban reason and duration and surface it to the player.
+        /// This endpoint does not require an active player session.
+        /// </summary>
+        /// <param name="playerUlid">The ULID of the player to query.</param>
+        /// <param name="onComplete">onComplete Action for handling the response of type LootLockerBanStatusResponse</param>
+        public static void GetPlayerBanStatus(string playerUlid, Action<LootLockerBanStatusResponse> onComplete)
+        {
+            if (!CheckInitialized(true))
+            {
+                onComplete?.Invoke(LootLockerResponseFactory.SDKNotInitializedError<LootLockerBanStatusResponse>(null));
+                return;
+            }
+
+            if (string.IsNullOrEmpty(playerUlid))
+            {
+                onComplete?.Invoke(LootLockerResponseFactory.ClientError<LootLockerBanStatusResponse>("playerUlid must not be null or empty", null));
+                return;
+            }
+
+            LootLockerServerRequest.CallAPI(null,
+                LootLockerEndPoints.banStatusRequest.endPoint, LootLockerEndPoints.banStatusRequest.httpMethod,
+                LootLockerJson.SerializeObject(new LootLockerBanStatusRequest { player_id = playerUlid }),
+                onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); },
+                useAuthToken: false
+            );
+        }
         #endregion
 
         #region Event System

--- a/Runtime/Game/Requests/LootLockerBanRequest.cs
+++ b/Runtime/Game/Requests/LootLockerBanRequest.cs
@@ -1,0 +1,56 @@
+using LootLocker.Requests;
+
+namespace LootLocker
+{
+    /// <summary>
+    /// Details about a player's active ban.
+    /// </summary>
+    public class LootLockerBanInfo
+    {
+        /// <summary>
+        /// The reason for the ban. One of "manual" or "chargeback".
+        /// </summary>
+        public string ban_reason { get; set; }
+
+        /// <summary>
+        /// The time the ban was issued, as an ISO 8601 timestamp.
+        /// </summary>
+        public string banned_on { get; set; }
+
+        /// <summary>
+        /// The time the ban expires, as an ISO 8601 timestamp.
+        /// Null when the ban is permanent; check the <see cref="permanent"/> field to confirm.
+        /// </summary>
+        public string banned_until { get; set; }
+
+        /// <summary>
+        /// True if the ban has no expiry date.
+        /// </summary>
+        public bool permanent { get; set; }
+    }
+}
+
+namespace LootLocker.Requests
+{
+    public class LootLockerBanStatusRequest
+    {
+        public string game_api_key { get; set; } = LootLockerConfig.current.apiKey;
+        public string player_id { get; set; }
+    }
+
+    /// <summary>
+    /// Response for <see cref="LootLockerSDKManager.GetPlayerBanStatus"/>.
+    /// </summary>
+    public class LootLockerBanStatusResponse : LootLockerResponse
+    {
+        /// <summary>
+        /// Whether the player is currently banned.
+        /// </summary>
+        public bool is_banned { get; set; }
+
+        /// <summary>
+        /// Details about the active ban. Populated when <see cref="is_banned"/> is true.
+        /// </summary>
+        public LootLockerBanInfo ban { get; set; }
+    }
+}

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs
@@ -1,0 +1,52 @@
+using System;
+using LootLocker;
+
+namespace LootLockerTestConfigurationUtils
+{
+    public static class LootLockerTestPlayerBan
+    {
+        /// <summary>
+        /// Bans a player using the admin API. Creates a permanent manual ban.
+        /// </summary>
+        /// <param name="playerUlid">The ULID of the player to ban.</param>
+        /// <param name="onComplete">Called with the raw response when the request completes.</param>
+        public static void BanPlayer(string playerUlid, Action<LootLockerResponse> onComplete)
+        {
+            if (string.IsNullOrEmpty(LootLockerConfig.current.adminToken))
+            {
+                onComplete?.Invoke(null);
+                return;
+            }
+
+            var endpoint = LootLockerTestConfigurationEndpoints.banPlayer;
+            string formattedEndpoint = string.Format(endpoint.endPoint, playerUlid);
+
+            LootLockerAdminRequest.Send(formattedEndpoint, endpoint.httpMethod, "{}", serverResponse =>
+            {
+                onComplete?.Invoke(serverResponse);
+            }, true);
+        }
+
+        /// <summary>
+        /// Unbans a player using the admin API.
+        /// </summary>
+        /// <param name="playerUlid">The ULID of the player to unban.</param>
+        /// <param name="onComplete">Called with the raw response when the request completes.</param>
+        public static void UnbanPlayer(string playerUlid, Action<LootLockerResponse> onComplete)
+        {
+            if (string.IsNullOrEmpty(LootLockerConfig.current.adminToken))
+            {
+                onComplete?.Invoke(null);
+                return;
+            }
+
+            var endpoint = LootLockerTestConfigurationEndpoints.unbanPlayer;
+            string formattedEndpoint = string.Format(endpoint.endPoint, playerUlid);
+
+            LootLockerAdminRequest.Send(formattedEndpoint, endpoint.httpMethod, null, serverResponse =>
+            {
+                onComplete?.Invoke(serverResponse);
+            }, true);
+        }
+    }
+}

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs
@@ -14,7 +14,7 @@ namespace LootLockerTestConfigurationUtils
         {
             if (string.IsNullOrEmpty(LootLockerConfig.current.adminToken))
             {
-                onComplete?.Invoke(null);
+                onComplete?.Invoke(new LootLockerResponse { success = false, errorData = new LootLockerErrorData { message = "Not logged in" } });
                 return;
             }
 
@@ -36,7 +36,7 @@ namespace LootLockerTestConfigurationUtils
         {
             if (string.IsNullOrEmpty(LootLockerConfig.current.adminToken))
             {
-                onComplete?.Invoke(null);
+                onComplete?.Invoke(new LootLockerResponse { success = false, errorData = new LootLockerErrorData { message = "Not logged in" } });
                 return;
             }
 

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationEndpoints.cs
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationEndpoints.cs
@@ -132,6 +132,10 @@ namespace LootLockerTestConfigurationUtils
 
         [Header("LootLocker Admin API Game Config")]
         public static EndPointClass setGameConfig = new EndPointClass("game/#GAMEID#/config/{0}", LootLockerHTTPMethod.POST, LootLockerCallerRole.Admin);
+
+        [Header("LootLocker Admin API Player Ban Operations")]
+        public static EndPointClass banPlayer = new EndPointClass("game/#GAMEID#/player/{0}/bans", LootLockerHTTPMethod.POST, LootLockerCallerRole.Admin);
+        public static EndPointClass unbanPlayer = new EndPointClass("game/#GAMEID#/player/{0}/bans", LootLockerHTTPMethod.DELETE, LootLockerCallerRole.Admin);
     }
     #endregion
 }

--- a/Tests/LootLockerTests/PlayMode/BanTest.cs
+++ b/Tests/LootLockerTests/PlayMode/BanTest.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections;
+using LootLocker;
+using LootLocker.Requests;
+using LootLockerTestConfigurationUtils;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace LootLockerTests.PlayMode
+{
+    public class BanTest
+    {
+        private LootLockerTestGame gameUnderTest = null;
+        private LootLockerConfig configCopy = null;
+        private static int TestCounter = 0;
+        private bool SetupFailed = false;
+
+        [UnitySetUp]
+        public IEnumerator Setup()
+        {
+            TestCounter++;
+            configCopy = LootLockerConfig.current;
+            Debug.Log($"##### Start of {this.GetType().Name} test no.{TestCounter} setup #####");
+
+            if (!LootLockerConfig.ClearSettings())
+            {
+                Debug.LogError("Could not clear LootLocker config");
+            }
+
+            bool gameCreationCallCompleted = false;
+            LootLockerTestGame.CreateGame(testName: this.GetType().Name + TestCounter + " ", onComplete: (success, errorMessage, game) =>
+            {
+                if (!success)
+                {
+                    SetupFailed = true;
+                    gameCreationCallCompleted = true;
+                    return;
+                }
+                gameUnderTest = game;
+                gameCreationCallCompleted = true;
+            });
+            yield return new WaitUntil(() => gameCreationCallCompleted);
+            if (SetupFailed) { yield break; }
+
+            gameUnderTest?.SwitchToStageEnvironment();
+
+            bool enableGuestLoginCallCompleted = false;
+            gameUnderTest?.EnableGuestLogin((success, errorMessage) =>
+            {
+                if (!success) { SetupFailed = true; }
+                enableGuestLoginCallCompleted = true;
+            });
+            yield return new WaitUntil(() => enableGuestLoginCallCompleted);
+            if (SetupFailed) { yield break; }
+
+            Assert.IsTrue(gameUnderTest?.InitializeLootLockerSDK(), "Failed to initialize LootLocker");
+
+            Debug.Log($"##### Start of {this.GetType().Name} test no.{TestCounter} test case #####");
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            Debug.Log($"##### End of {this.GetType().Name} test no.{TestCounter} test case #####");
+            if (gameUnderTest != null)
+            {
+                bool gameDeletionCallCompleted = false;
+                gameUnderTest.DeleteGame(((success, errorMessage) =>
+                {
+                    if (!success) { Debug.LogError(errorMessage); }
+                    gameUnderTest = null;
+                    gameDeletionCallCompleted = true;
+                }));
+                yield return new WaitUntil(() => gameDeletionCallCompleted);
+            }
+            LootLockerStateData.ClearAllSavedStates();
+            LootLockerConfig.CreateNewSettings(configCopy);
+            Debug.Log($"##### End of {this.GetType().Name} test no.{TestCounter} tear down #####");
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI"), Category("LootLockerCIFast")]
+        public IEnumerator GetPlayerBanStatus_ForUnbannedPlayer_ReturnsNotBanned()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // Given
+            LootLockerGuestSessionResponse sessionResponse = null;
+            bool sessionCompleted = false;
+            LootLockerSDKManager.StartGuestSession(Guid.NewGuid().ToString(), response =>
+            {
+                sessionResponse = response;
+                sessionCompleted = true;
+            });
+            yield return new WaitUntil(() => sessionCompleted);
+            Assert.IsTrue(sessionResponse.success, "Failed to start guest session for setup");
+
+            // When
+            LootLockerBanStatusResponse banStatusResponse = null;
+            bool banStatusCompleted = false;
+            LootLockerSDKManager.GetPlayerBanStatus(sessionResponse.player_ulid, response =>
+            {
+                banStatusResponse = response;
+                banStatusCompleted = true;
+            });
+            yield return new WaitUntil(() => banStatusCompleted);
+
+            // Then
+            Assert.IsTrue(banStatusResponse.success, "Expected GetPlayerBanStatus to succeed");
+            Assert.IsFalse(banStatusResponse.is_banned, "Expected player to not be banned");
+            Assert.IsNull(banStatusResponse.ban, "Expected no ban details for an unbanned player");
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI")]
+        public IEnumerator StartSession_ForBannedPlayer_Returns403WithBanInfo()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // Given - start session to obtain the player ULID and identifier
+            string playerIdentifier = Guid.NewGuid().ToString();
+            LootLockerGuestSessionResponse sessionResponse = null;
+            bool sessionCompleted = false;
+            LootLockerSDKManager.StartGuestSession(playerIdentifier, response =>
+            {
+                sessionResponse = response;
+                sessionCompleted = true;
+            });
+            yield return new WaitUntil(() => sessionCompleted);
+            Assert.IsTrue(sessionResponse.success, "Failed to start initial guest session");
+
+            string playerUlid = sessionResponse.player_ulid;
+            LootLockerStateData.ClearAllSavedStates();
+
+            bool banCompleted = false;
+            LootLockerResponse banResponse = null;
+            LootLockerTestPlayerBan.BanPlayer(playerUlid, response =>
+            {
+                banResponse = response;
+                banCompleted = true;
+            });
+            yield return new WaitUntil(() => banCompleted);
+            Assert.IsTrue(banResponse?.success, "Failed to ban player via admin API");
+
+            // When - try to start a new session with the banned player's identifier
+            LootLockerGuestSessionResponse bannedSessionResponse = null;
+            bool bannedSessionCompleted = false;
+            LootLockerSDKManager.StartGuestSession(playerIdentifier, response =>
+            {
+                bannedSessionResponse = response;
+                bannedSessionCompleted = true;
+            });
+            yield return new WaitUntil(() => bannedSessionCompleted);
+
+            // Then
+            Assert.IsFalse(bannedSessionResponse.success, "Expected session start to fail for a banned player");
+            Assert.AreEqual(403, bannedSessionResponse.statusCode, "Expected 403 status code for a banned player");
+            Assert.AreEqual("player_banned", bannedSessionResponse.errorData?.code, "Expected player_banned error code");
+            Assert.IsNotNull(bannedSessionResponse.errorData?.ban, "Expected ban info to be present in the error data");
+            Assert.IsFalse(string.IsNullOrEmpty(bannedSessionResponse.errorData?.ban?.ban_reason), "Expected ban_reason to be populated");
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI")]
+        public IEnumerator GetPlayerBanStatus_ForBannedPlayer_ReturnsIsBannedWithDetails()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // Given - start session to obtain the player ULID, then ban the player
+            LootLockerGuestSessionResponse sessionResponse = null;
+            bool sessionCompleted = false;
+            LootLockerSDKManager.StartGuestSession(Guid.NewGuid().ToString(), response =>
+            {
+                sessionResponse = response;
+                sessionCompleted = true;
+            });
+            yield return new WaitUntil(() => sessionCompleted);
+            Assert.IsTrue(sessionResponse.success, "Failed to start guest session");
+
+            string playerUlid = sessionResponse.player_ulid;
+            LootLockerStateData.ClearAllSavedStates();
+
+            bool banCompleted = false;
+            LootLockerResponse banResponse = null;
+            LootLockerTestPlayerBan.BanPlayer(playerUlid, response =>
+            {
+                banResponse = response;
+                banCompleted = true;
+            });
+            yield return new WaitUntil(() => banCompleted);
+            Assert.IsTrue(banResponse?.success, "Failed to ban player via admin API");
+
+            // When
+            LootLockerBanStatusResponse banStatusResponse = null;
+            bool banStatusCompleted = false;
+            LootLockerSDKManager.GetPlayerBanStatus(playerUlid, response =>
+            {
+                banStatusResponse = response;
+                banStatusCompleted = true;
+            });
+            yield return new WaitUntil(() => banStatusCompleted);
+
+            // Then
+            Assert.IsTrue(banStatusResponse.success, "Expected GetPlayerBanStatus to succeed");
+            Assert.IsTrue(banStatusResponse.is_banned, "Expected player to be banned");
+            Assert.IsNotNull(banStatusResponse.ban, "Expected ban details to be populated");
+            Assert.IsFalse(string.IsNullOrEmpty(banStatusResponse.ban?.ban_reason), "Expected ban_reason to be populated");
+            Assert.IsFalse(string.IsNullOrEmpty(banStatusResponse.ban?.banned_on), "Expected banned_on to be populated");
+            Assert.IsTrue(banStatusResponse.ban?.permanent ?? false, "Expected permanent ban (no banned_until)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements [lootlocker/index#1501](https://github.com/lootlocker/index/issues/1501) — Add player ban reason to SDKs.

Two changes:
1. **New `GetPlayerBanStatus` method** — calls `POST /game/session/ban-status` using the game API key (no player session required). Returns whether a player is banned and, if so, the ban details.
2. **Ban info on session 403** — when a session start returns 403 with `code: "player_banned"`, the `errorData.ban` field is now populated with the ban reason, timestamps, and permanent flag.

## Files changed

### New files
- `Runtime/Game/Requests/LootLockerBanRequest.cs` — `LootLockerBanInfo`, `LootLockerBanStatusRequest`, `LootLockerBanStatusResponse`
- `Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs` — `LootLockerTestPlayerBan` helper (ban/unban via admin API)
- `Tests/LootLockerTests/PlayMode/BanTest.cs` — 3 integration tests

### Modified files
- `Runtime/Client/LootLockerErrorData.cs` — added `LootLockerBanInfo ban` field
- `Runtime/Client/LootLockerEndPoints.cs` — added `banStatusRequest` endpoint
- `Runtime/Game/LootLockerSDKManager.cs` — added `GetPlayerBanStatus(playerUlid, onComplete)`
- `Tests/LootLockerTestUtils/LootLockerTestConfigurationEndpoints.cs` — added `banPlayer` / `unbanPlayer` admin endpoints

## Tests
- `GetPlayerBanStatus_ForUnbannedPlayer_ReturnsNotBanned` (`LootLockerCIFast`)
- `StartSession_ForBannedPlayer_Returns403WithBanInfo` (`LootLockerCI`)
- `GetPlayerBanStatus_ForBannedPlayer_ReturnsIsBannedWithDetails` (`LootLockerCI`)