### PR TITLE
Add StartSessionManual to LootLockerSDKManager

### DIFF
--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -329,9 +329,15 @@ namespace LootLocker.Requests
         /// At minimum, <paramref name="playerData"/> must have a non-empty <c>SessionToken</c> and <c>ULID</c>. All other fields are optional but recommended for full SDK functionality.
         /// </summary>
         /// <param name="playerData">Player state to cache and use for future requests</param>
-        /// <returns>True if the state was saved successfully; false if <paramref name="playerData"/> was null or missing required fields.</returns>
+        /// <returns>True if the state was saved successfully; false if <paramref name="playerData"/> was null or missing required fields, or if the SDK is not initialized.</returns>
         public static bool StartSessionManual(LootLockerPlayerData playerData)
         {
+            if (!CheckInitialized(true))
+            {
+                LootLockerLogger.Log("StartSessionManual called before the SDK was initialized", LootLockerLogger.LogLevel.Warning);
+                return false;
+            }
+
             if (playerData == null)
             {
                 LootLockerLogger.Log("StartSessionManual called with null playerData", LootLockerLogger.LogLevel.Warning);

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -324,6 +324,36 @@ namespace LootLocker.Requests
         #region Authentication
         /// @ingroup Authentication
         /// <summary>
+        /// Add a player state manually from externally sourced data (e.g. after a server token exchange) without performing an authentication call.
+        ///
+        /// At minimum, <paramref name="playerData"/> must have a non-empty <c>SessionToken</c> and <c>ULID</c>. All other fields are optional but recommended for full SDK functionality.
+        /// </summary>
+        /// <param name="playerData">Player state to cache and use for future requests</param>
+        /// <returns>True if the state was saved successfully; false if <paramref name="playerData"/> was null or missing required fields.</returns>
+        public static bool StartSessionManual(LootLockerPlayerData playerData)
+        {
+            if (playerData == null)
+            {
+                LootLockerLogger.Log("StartSessionManual called with null playerData", LootLockerLogger.LogLevel.Warning);
+                return false;
+            }
+            if (string.IsNullOrEmpty(playerData.SessionToken))
+            {
+                LootLockerLogger.Log("StartSessionManual called with empty SessionToken", LootLockerLogger.LogLevel.Warning);
+                return false;
+            }
+            if (string.IsNullOrEmpty(playerData.ULID))
+            {
+                LootLockerLogger.Log("StartSessionManual called with empty ULID", LootLockerLogger.LogLevel.Warning);
+                return false;
+            }
+
+            LootLockerEventSystem.TriggerSessionStarted(playerData);
+            return true;
+        }
+
+        /// @ingroup Authentication
+        /// <summary>
         /// Verify the player's identity with the server and selected platform.
         /// </summary>
         /// <param name="deviceId"></param>

--- a/Tests/LootLockerTests/PlayMode/StartSessionManualTest.cs
+++ b/Tests/LootLockerTests/PlayMode/StartSessionManualTest.cs
@@ -1,0 +1,158 @@
+using System.Collections;
+using LootLocker;
+using LootLocker.Requests;
+using LootLockerTestConfigurationUtils;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace LootLockerTests.PlayMode
+{
+    public class StartSessionManualTest
+    {
+        private LootLockerTestGame gameUnderTest = null;
+        private LootLockerConfig configCopy = null;
+        private static int TestCounter = 0;
+        private bool SetupFailed = false;
+
+        [UnitySetUp]
+        public IEnumerator Setup()
+        {
+            TestCounter++;
+            configCopy = LootLockerConfig.current;
+            Debug.Log($"##### Start of {this.GetType().Name} test no.{TestCounter} setup #####");
+
+            if (!LootLockerConfig.ClearSettings())
+            {
+                Debug.LogError("Could not clear LootLocker config");
+            }
+
+            LootLockerConfig.current.logLevel = LootLockerLogger.LogLevel.Debug;
+
+            // Create game
+            bool gameCreationCallCompleted = false;
+            LootLockerTestGame.CreateGame(testName: this.GetType().Name + TestCounter + " ", onComplete: (success, errorMessage, game) =>
+            {
+                if (!success)
+                {
+                    gameCreationCallCompleted = true;
+                    Debug.LogError(errorMessage);
+                    SetupFailed = true;
+                }
+                gameUnderTest = game;
+                gameCreationCallCompleted = true;
+            });
+            yield return new WaitUntil(() => gameCreationCallCompleted);
+            if (SetupFailed)
+            {
+                yield break;
+            }
+            gameUnderTest?.SwitchToStageEnvironment();
+
+            Assert.IsTrue(gameUnderTest?.InitializeLootLockerSDK(), "Failed to initialize LootLocker");
+
+            Debug.Log($"##### Start of {this.GetType().Name} test no.{TestCounter} test case #####");
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            Debug.Log($"##### End of {this.GetType().Name} test no.{TestCounter} test case #####");
+            if (gameUnderTest != null)
+            {
+                bool gameDeletionCallCompleted = false;
+                gameUnderTest.DeleteGame(((success, errorMessage) =>
+                {
+                    if (!success)
+                    {
+                        Debug.LogError(errorMessage);
+                    }
+                    gameUnderTest = null;
+                    gameDeletionCallCompleted = true;
+                }));
+                yield return new WaitUntil(() => gameDeletionCallCompleted);
+            }
+
+            LootLockerStateData.ClearAllSavedStates();
+            LootLockerConfig.CreateNewSettings(configCopy);
+            Debug.Log($"##### End of {this.GetType().Name} test no.{TestCounter} tear down #####");
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI"), Category("LootLockerCIFast")]
+        public IEnumerator StartSessionManual_WithNullPlayerData_ReturnsFalse()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // When
+            bool result = LootLockerSDKManager.StartSessionManual(null);
+
+            // Then
+            Assert.IsFalse(result, "Expected StartSessionManual to return false with null playerData");
+
+            yield return null;
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI"), Category("LootLockerCIFast")]
+        public IEnumerator StartSessionManual_WithEmptySessionToken_ReturnsFalse()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // Given
+            var playerData = new LootLockerPlayerData { SessionToken = "", ULID = "01JVWXYZ0123456789ABCDEFGH" };
+
+            // When
+            bool result = LootLockerSDKManager.StartSessionManual(playerData);
+
+            // Then
+            Assert.IsFalse(result, "Expected StartSessionManual to return false with empty SessionToken");
+
+            yield return null;
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI"), Category("LootLockerCIFast")]
+        public IEnumerator StartSessionManual_WithEmptyUlid_ReturnsFalse()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // Given
+            var playerData = new LootLockerPlayerData { SessionToken = "fake-session-token", ULID = "" };
+
+            // When
+            bool result = LootLockerSDKManager.StartSessionManual(playerData);
+
+            // Then
+            Assert.IsFalse(result, "Expected StartSessionManual to return false with empty ULID");
+
+            yield return null;
+        }
+
+        [UnityTest, Category("LootLocker"), Category("LootLockerCI"), Category("LootLockerCIFast")]
+        public IEnumerator StartSessionManual_WithValidData_PersistsState()
+        {
+            Assert.IsFalse(SetupFailed, "Failed to setup game");
+
+            // Given
+            string expectedToken = "fake-session-token";
+            string expectedUlid = "01JVWXYZ0123456789ABCDEFGH";
+            var playerData = new LootLockerPlayerData
+            {
+                SessionToken = expectedToken,
+                ULID = expectedUlid,
+                Name = "Test Player"
+            };
+
+            // When
+            bool result = LootLockerSDKManager.StartSessionManual(playerData);
+
+            // Then
+            Assert.IsTrue(result, "Expected StartSessionManual to return true with valid data");
+            var storedData = LootLockerSDKManager.GetPlayerDataForPlayerWithUlid(expectedUlid);
+            Assert.IsNotNull(storedData, "Expected state to be persisted after StartSessionManual");
+            Assert.AreEqual(expectedToken, storedData.SessionToken, "Expected stored SessionToken to match provided value");
+            Assert.AreEqual(expectedUlid, storedData.ULID, "Expected stored ULID to match provided value");
+
+            yield return null;
+        }
+
+    }
+}

--- a/Tests/LootLockerTests/PlayMode/StartSessionManualTest.cs.meta
+++ b/Tests/LootLockerTests/PlayMode/StartSessionManualTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 320ea9b2b5121b24ca0a767bdca37bb8


### PR DESCRIPTION
## Summary

Adds `StartSessionManual(LootLockerPlayerData playerData)` to `LootLockerSDKManager`, allowing developers to inject externally sourced player state (e.g. after a server token exchange) without performing an authentication API call.

Closes lootlocker/index#1179

## Changes

- **`Runtime/Game/LootLockerSDKManager.cs`** — new `public static bool StartSessionManual(LootLockerPlayerData playerData)` method in `#region Authentication`

## Behaviour

- Validates that `playerData` is non-null and has a non-empty `SessionToken` and `ULID`; logs a warning and returns `false` if not
- On success, calls `LootLockerEventSystem.TriggerSessionStarted(playerData)` — the same pipeline used by all other auth methods — which persists state to memory and PlayerPrefs and notifies any registered listeners
- Returns `true` on success

## Testing

Local compile check: ✅ PASSED