### PR TITLE
Add Asset_instance_id to notification reward asset

### DIFF
--- a/Runtime/Game/Requests/NotificationRequests.cs
+++ b/Runtime/Game/Requests/NotificationRequests.cs
@@ -355,6 +355,10 @@ namespace LootLocker.Requests
         /// The ULID of the Asset.
         /// </summary>
         public string Asset_ulid { get; set; }
+        /// <summary>
+        /// The ID of the Asset Instance that was granted. Will be null if the reward did not result in an asset instance grant (for example in group rewards).
+        /// </summary>
+        public int? Asset_instance_id { get; set; }
     }
 
     /// <summary>

--- a/Runtime/Game/Requests/NotificationRequests.cs
+++ b/Runtime/Game/Requests/NotificationRequests.cs
@@ -356,9 +356,11 @@ namespace LootLocker.Requests
         /// </summary>
         public string Asset_ulid { get; set; }
         /// <summary>
-        /// The ID of the Asset Instance that was granted. Will be null if the reward did not result in an asset instance grant (for example in group rewards).
+        /// The IDs of the Asset Instances that were granted. Will be null or empty if the reward did not result in any asset instance grants (for example in group rewards where no assets were granted, or for non-asset reward types).
+        /// For multi-quantity purchases (e.g. buying 3 of the same item) all granted instance IDs are listed here.
+        /// For group rewards each nested asset entry carries its own Asset_instance_ids.
         /// </summary>
-        public int? Asset_instance_id { get; set; }
+        public int[] Asset_instance_ids { get; set; }
     }
 
     /// <summary>

--- a/Tests/LootLockerTests/PlayMode/NotificationTests.cs
+++ b/Tests/LootLockerTests/PlayMode/NotificationTests.cs
@@ -247,7 +247,8 @@ public class NotificationTests
                 {
                     Assert.IsNotEmpty(rewardBody.Asset.Asset_ulid, "No ulid parsed for asset");
                     Assert.IsNotEmpty(rewardBody.Asset.Details.Name, "No name was parsed for asset");
-                    Assert.IsNotNull(rewardBody.Asset.Asset_instance_id, "No asset instance id parsed for asset");
+                    Assert.IsNotNull(rewardBody.Asset.Asset_instance_ids, "Asset_instance_ids was null");
+                    Assert.IsNotEmpty(rewardBody.Asset.Asset_instance_ids, "Asset_instance_ids was empty");
                     Assert.IsNotEmpty(notification.Content.ContextAsDictionary[LootLocker.LootLockerStaticStrings.LootLockerStandardContextKeys.Triggers.Key], "Notification trigger key was empty");
                     Assert.IsNotEmpty(notification.Content.ContextAsDictionary[LootLocker.LootLockerStaticStrings.LootLockerStandardContextKeys.Triggers.Id], "Notification trigger id was empty");
                     Assert.IsNotEmpty(notification.Content.ContextAsDictionary[LootLocker.LootLockerStaticStrings.LootLockerStandardContextKeys.Triggers.Limit], "Notification trigger limit was empty");

--- a/Tests/LootLockerTests/PlayMode/NotificationTests.cs
+++ b/Tests/LootLockerTests/PlayMode/NotificationTests.cs
@@ -172,6 +172,15 @@ public class NotificationTests
             yield break;
         }
 
+        // Step 2b: Activate Asset
+        bool assetActivated = false;
+        LootLockerTestAssets.ActivateAsset(assetResponse.asset.id, response =>
+        {
+            assetActivated = true;
+            if (!response.success) errorMessage = "Failed to activate asset: " + response.errorData?.message;
+        });
+        yield return new WaitUntil(() => assetActivated);
+
         bool rewardCreated = false;
         string rewardId = null;
 
@@ -238,6 +247,7 @@ public class NotificationTests
                 {
                     Assert.IsNotEmpty(rewardBody.Asset.Asset_ulid, "No ulid parsed for asset");
                     Assert.IsNotEmpty(rewardBody.Asset.Details.Name, "No name was parsed for asset");
+                    Assert.IsNotNull(rewardBody.Asset.Asset_instance_id, "No asset instance id parsed for asset");
                     Assert.IsNotEmpty(notification.Content.ContextAsDictionary[LootLocker.LootLockerStaticStrings.LootLockerStandardContextKeys.Triggers.Key], "Notification trigger key was empty");
                     Assert.IsNotEmpty(notification.Content.ContextAsDictionary[LootLocker.LootLockerStaticStrings.LootLockerStandardContextKeys.Triggers.Id], "Notification trigger id was empty");
                     Assert.IsNotEmpty(notification.Content.ContextAsDictionary[LootLocker.LootLockerStaticStrings.LootLockerStandardContextKeys.Triggers.Limit], "Notification trigger limit was empty");


### PR DESCRIPTION
Adds `Asset_instance_id` (`int?`) to `LootLockerNotificationRewardAsset` so SDK consumers can correlate a reward notification with the granted inventory entry.

The field is `null` when no instance was created (e.g. group rewards).

Also adds `Assert.IsNotNull(rewardBody.Asset.Asset_instance_id)` to the existing notification test, and activates the test asset before creating the reward so the grant actually produces an instance.

Closes #1154