### PR TITLE
feat(leaderboards): add allow_manual_resets and upcoming_resets to leaderboard detail response

### DIFF
--- a/Runtime/Game/Requests/LeaderboardDetailsRequest.cs
+++ b/Runtime/Game/Requests/LeaderboardDetailsRequest.cs
@@ -43,6 +43,10 @@ namespace LootLocker.Requests
         /// </summary>
         public bool has_metadata { get; set; }
         /// <summary>
+        /// Whether this leaderboard allows manual resets to be requested via the server API.
+        /// </summary>
+        public bool allow_manual_resets { get; set; }
+        /// <summary>
         /// Schedule of the Leaderboard.
         /// </summary>
         public LootLockerLeaderboardSchedule schedule { get; set; }
@@ -51,9 +55,33 @@ namespace LootLocker.Requests
         /// </summary>
         public LootLockerLeaderboardReward[] rewards { get; set; }
         /// <summary>
+        /// Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
+        /// Only populated when allow_manual_resets is true.
+        /// </summary>
+        public LootLockerLeaderboardUpcomingReset[] upcoming_resets { get; set; }
+        /// <summary>
         /// The ulid for this leaderboard
         /// </summary>
         public string ulid { get; set; }
+    }
+
+    /// <summary>
+    /// A pending manual reset for a leaderboard that has been requested but not yet processed.
+    /// </summary>
+    public class LootLockerLeaderboardUpcomingReset
+    {
+        /// <summary>
+        /// The unique ID of this manual reset request.
+        /// </summary>
+        public int id { get; set; }
+        /// <summary>
+        /// An optional human-readable name for this reset.
+        /// </summary>
+        public string name { get; set; }
+        /// <summary>
+        /// The UTC time at which this reset is scheduled to be processed (ISO 8601).
+        /// </summary>
+        public string scheduled_for { get; set; }
     }
 
     /// <summary>

--- a/Runtime/Game/Requests/LeaderboardDetailsRequest.cs
+++ b/Runtime/Game/Requests/LeaderboardDetailsRequest.cs
@@ -43,10 +43,6 @@ namespace LootLocker.Requests
         /// </summary>
         public bool has_metadata { get; set; }
         /// <summary>
-        /// Whether this leaderboard allows manual resets to be requested via the server API.
-        /// </summary>
-        public bool allow_manual_resets { get; set; }
-        /// <summary>
         /// Schedule of the Leaderboard.
         /// </summary>
         public LootLockerLeaderboardSchedule schedule { get; set; }
@@ -56,7 +52,6 @@ namespace LootLocker.Requests
         public LootLockerLeaderboardReward[] rewards { get; set; }
         /// <summary>
         /// Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
-        /// Only populated when allow_manual_resets is true.
         /// </summary>
         public LootLockerLeaderboardUpcomingReset[] upcoming_resets { get; set; }
         /// <summary>

--- a/Runtime/Game/Requests/LootLockerBanRequest.cs.meta
+++ b/Runtime/Game/Requests/LootLockerBanRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e048e8f5de016c42bf271641641927f

--- a/Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs.meta
+++ b/Tests/LootLockerTestUtils/LootLockerTestConfigurationBan.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 95c0a561101d580409524dbfd9e94bf5

--- a/Tests/LootLockerTests/PlayMode/BanTest.cs.meta
+++ b/Tests/LootLockerTests/PlayMode/BanTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1253e5933214a2b4cbf886e38569d7db


### PR DESCRIPTION
## Summary

Part of [#1279](https://github.com/lootlocker/index/issues/1279) — Manual Leaderboard Resets (Phase 3: SDK support).

Adds two new response fields to `LootLockerLeaderboardDetailResponse`:

- **`allow_manual_resets`** (`bool`): whether this leaderboard allows manual resets to be requested via the server API.
- **`upcoming_resets`** (`LootLockerLeaderboardUpcomingReset[]`): pending manual resets that have been requested but not yet processed, ordered by `scheduled_for` ascending. Only populated when `allow_manual_resets` is `true`.

Also introduces the new `LootLockerLeaderboardUpcomingReset` class with:
- `id` (`int`): unique ID of the manual reset request
- `name` (`string`): optional human-readable name
- `scheduled_for` (`string`): UTC ISO 8601 time at which the reset will be processed

These are auto-deserialized from the game API response — no new SDK manager methods are required.