### PR TITLE
feat: Add connection state check method

### DIFF
--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -9679,8 +9679,9 @@ namespace LootLocker.Requests
         ///   <item><see cref="LootLockerConnectionState.ServerError"/> – the server returned a 5xx error.</item>
         /// </list>
         ///
-        /// Note: This method does not attempt to refresh the session token. Use the appropriate session refresh method
-        /// if you want to recover from an expired token.
+        /// Note: If <see cref="LootLockerConfig.allowTokenRefresh"/> is enabled, the underlying HTTP client may automatically attempt
+        /// a session refresh when the ping returns 401 or 403. This method does not explicitly request a refresh;
+        /// it reports the resulting state after any such automatic refresh behavior.
         /// </summary>
         /// <param name="onComplete">onComplete Action for handling the response of type LootLockerConnectionStateResponse</param>
         /// <param name="forPlayerWithUlid">Optional : Execute the request for the specified player. If not supplied, the default player will be used.</param>

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -9666,6 +9666,70 @@ namespace LootLocker.Requests
 
         /// @ingroup Misc
         /// <summary>
+        /// Check the current connection and session state for a player.
+        ///
+        /// Performs a lightweight ping to the LootLocker servers and returns one of the following states:
+        /// <list type="bullet">
+        ///   <item><see cref="LootLockerConnectionState.NotInitialized"/> – the SDK has not been initialized.</item>
+        ///   <item><see cref="LootLockerConnectionState.NotSignedIn"/> – no session exists for the player.</item>
+        ///   <item><see cref="LootLockerConnectionState.NoConnection"/> – the device has no internet or the server did not respond.</item>
+        ///   <item><see cref="LootLockerConnectionState.SignedInAndConnected"/> – the session is valid and the server is reachable.</item>
+        ///   <item><see cref="LootLockerConnectionState.SessionExpired"/> – a session exists but the token has expired (401) or another non-ban 403 was returned.</item>
+        ///   <item><see cref="LootLockerConnectionState.Banned"/> – the player is currently banned. <see cref="LootLockerConnectionStateResponse.BanDetails"/> is populated.</item>
+        ///   <item><see cref="LootLockerConnectionState.ServerError"/> – the server returned a 5xx error.</item>
+        /// </list>
+        ///
+        /// Note: This method does not attempt to refresh the session token. Use the appropriate session refresh method
+        /// if you want to recover from an expired token.
+        /// </summary>
+        /// <param name="onComplete">onComplete Action for handling the response of type LootLockerConnectionStateResponse</param>
+        /// <param name="forPlayerWithUlid">Optional : Execute the request for the specified player. If not supplied, the default player will be used.</param>
+        public static void CheckConnectionStatus(Action<LootLockerConnectionStateResponse> onComplete, string forPlayerWithUlid = null)
+        {
+            if (!LootLockerLifecycleManager.IsReady)
+            {
+                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                {
+                    success = false,
+                    State = LootLockerConnectionState.NotInitialized,
+                    statusCode = 0,
+                });
+                return;
+            }
+
+            if (string.IsNullOrEmpty(forPlayerWithUlid))
+            {
+                forPlayerWithUlid = GetDefaultPlayerUlid();
+            }
+
+            var playerData = LootLockerStateData.GetPlayerDataForPlayerWithUlidWithoutChangingState(forPlayerWithUlid);
+            if (string.IsNullOrEmpty(playerData?.SessionToken))
+            {
+                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                {
+                    success = false,
+                    State = LootLockerConnectionState.NotSignedIn,
+                    statusCode = 0,
+                });
+                return;
+            }
+
+            if (UnityEngine.Application.internetReachability == UnityEngine.NetworkReachability.NotReachable)
+            {
+                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                {
+                    success = false,
+                    State = LootLockerConnectionState.NoConnection,
+                    statusCode = 0,
+                });
+                return;
+            }
+
+            LootLockerAPIManager.CheckConnectionStatus(forPlayerWithUlid, onComplete);
+        }
+
+        /// @ingroup Misc
+        /// <summary>
         ///  Get meta information about the game
         /// </summary>
         /// <param name="onComplete">onComplete Action for handling the response</param>

--- a/Runtime/Game/Requests/MiscRequests.cs
+++ b/Runtime/Game/Requests/MiscRequests.cs
@@ -1,5 +1,6 @@
 using System;
 using LootLocker.Requests;
+using UnityEngine;
 
 namespace LootLocker.Requests
 {
@@ -37,6 +38,51 @@ namespace LootLocker.Requests
         public LootLockerGameInfo info { get; set; }
     }
 
+    /// <summary>
+    /// The state of a player's connection and session with the LootLocker backend.
+    /// Returned by <see cref="LootLocker.Requests.LootLockerSDKManager.CheckConnectionStatus"/>.
+    /// </summary>
+    public enum LootLockerConnectionState
+    {
+        /// <summary>The SDK has not been initialized.</summary>
+        NotInitialized,
+        /// <summary>No session token exists for the specified player – they have not signed in.</summary>
+        NotSignedIn,
+        /// <summary>The session token is valid and the server is reachable.</summary>
+        SignedInAndConnected,
+        /// <summary>A session token exists but the server returned 401 – the token has expired.</summary>
+        SessionExpired,
+        /// <summary>A session token exists but the player is currently banned.</summary>
+        Banned,
+        /// <summary>The server could not be reached (no network, timeout, or status code 0).</summary>
+        NoConnection,
+        /// <summary>The server returned a 5xx error.</summary>
+        ServerError,
+    }
+
+    /// <summary>
+    /// Response for <see cref="LootLocker.Requests.LootLockerSDKManager.CheckConnectionStatus"/>.
+    /// </summary>
+    public class LootLockerConnectionStateResponse : LootLockerResponse
+    {
+        /// <summary>
+        /// The determined connection state for the player.
+        /// </summary>
+        public LootLockerConnectionState State { get; set; }
+
+        /// <summary>
+        /// The server timestamp returned by the ping. Populated only when <see cref="State"/> is
+        /// <see cref="LootLockerConnectionState.SignedInAndConnected"/>.
+        /// </summary>
+        public string ServerTime { get; set; }
+
+        /// <summary>
+        /// Details about the active ban. Populated only when <see cref="State"/> is
+        /// <see cref="LootLockerConnectionState.Banned"/>.
+        /// </summary>
+        public LootLockerBanInfo BanDetails { get; set; }
+    }
+
     //==================================================
     // Request Definitions
     //==================================================
@@ -65,6 +111,111 @@ namespace LootLocker
         {
             string body = LootLockerJson.SerializeObject(new LootLockerGameInfoRequest { api_key = LootLockerConfig.current.apiKey });
             LootLockerServerRequest.CallAPI("", LootLockerEndPoints.gameInfo.endPoint, LootLockerEndPoints.gameInfo.httpMethod, body, (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); }, useAuthToken: false);
+        }
+
+        public static void CheckConnectionStatus(string forPlayerWithUlid, Action<LootLockerConnectionStateResponse> onComplete)
+        {
+            EndPointClass pingEndpoint = LootLockerEndPoints.ping;
+            LootLockerServerRequest.CallAPI(forPlayerWithUlid, pingEndpoint.endPoint, pingEndpoint.httpMethod, null, (pingResponse) =>
+            {
+                if (pingResponse == null || pingResponse.statusCode == 0)
+                {
+                    onComplete?.Invoke(new LootLockerConnectionStateResponse
+                    {
+                        success = false,
+                        State = LootLockerConnectionState.NoConnection,
+                        statusCode = pingResponse?.statusCode ?? 0,
+                        text = pingResponse?.text,
+                        errorData = pingResponse?.errorData,
+                        requestContext = pingResponse?.requestContext,
+                    });
+                    return;
+                }
+
+                if (pingResponse.success)
+                {
+                    var successPing = LootLockerResponse.Deserialize<LootLockerPingResponse>(pingResponse);
+                    onComplete?.Invoke(new LootLockerConnectionStateResponse
+                    {
+                        success = true,
+                        State = LootLockerConnectionState.SignedInAndConnected,
+                        ServerTime = successPing?.date,
+                        statusCode = pingResponse.statusCode,
+                        text = pingResponse.text,
+                        requestContext = pingResponse.requestContext,
+                    });
+                    return;
+                }
+
+                int statusCode = pingResponse.statusCode;
+
+                if (statusCode >= 500)
+                {
+                    onComplete?.Invoke(new LootLockerConnectionStateResponse
+                    {
+                        success = false,
+                        State = LootLockerConnectionState.ServerError,
+                        statusCode = statusCode,
+                        text = pingResponse.text,
+                        errorData = pingResponse.errorData,
+                        requestContext = pingResponse.requestContext,
+                    });
+                    return;
+                }
+
+                // 401 = token expired (or auto-refresh of a banned player's session failed and synthesized a 401).
+                // 403 = forbidden – could also be a ban.
+                // In both cases, call ban-status to check whether the player is banned.
+                if (statusCode == 401 || statusCode == 403)
+                {
+                    LootLockerServerRequest.CallAPI(null,
+                        LootLockerEndPoints.banStatusRequest.endPoint,
+                        LootLockerEndPoints.banStatusRequest.httpMethod,
+                        LootLockerJson.SerializeObject(new LootLockerBanStatusRequest { player_id = forPlayerWithUlid }),
+                        (banResponse) =>
+                        {
+                            var banStatus = LootLockerResponse.Deserialize<LootLockerBanStatusResponse>(banResponse);
+                            if (banStatus != null && banStatus.success && banStatus.is_banned)
+                            {
+                                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                                {
+                                    success = false,
+                                    State = LootLockerConnectionState.Banned,
+                                    BanDetails = banStatus.ban,
+                                    statusCode = statusCode,
+                                    text = pingResponse.text,
+                                    errorData = pingResponse.errorData,
+                                    requestContext = pingResponse.requestContext,
+                                });
+                            }
+                            else
+                            {
+                                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                                {
+                                    success = false,
+                                    State = LootLockerConnectionState.SessionExpired,
+                                    statusCode = statusCode,
+                                    text = pingResponse.text,
+                                    errorData = pingResponse.errorData,
+                                    requestContext = pingResponse.requestContext,
+                                });
+                            }
+                        },
+                        useAuthToken: false);
+                    return;
+                }
+
+                // Any other failure (unlikely from ping, but handled conservatively)
+                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                {
+                    success = false,
+                    State = LootLockerConnectionState.SessionExpired,
+                    statusCode = statusCode,
+                    text = pingResponse.text,
+                    errorData = pingResponse.errorData,
+                    requestContext = pingResponse.requestContext,
+                });
+            });
         }
     }
 }

--- a/Runtime/Game/Requests/MiscRequests.cs
+++ b/Runtime/Game/Requests/MiscRequests.cs
@@ -1,6 +1,5 @@
 using System;
 using LootLocker.Requests;
-using UnityEngine;
 
 namespace LootLocker.Requests
 {
@@ -56,7 +55,7 @@ namespace LootLocker.Requests
         Banned,
         /// <summary>The server could not be reached (no network, timeout, or status code 0).</summary>
         NoConnection,
-        /// <summary>The server returned a 5xx error.</summary>
+        /// <summary>The server returned a 5xx error, or an unexpected non-success status code.</summary>
         ServerError,
     }
 
@@ -205,11 +204,12 @@ namespace LootLocker
                     return;
                 }
 
-                // Any other failure (unlikely from ping, but handled conservatively)
+                // Any other failure (e.g., 400, 404, 429 — unexpected for a ping, but handled conservatively).
+                // Map to ServerError rather than SessionExpired so State is consistent with statusCode.
                 onComplete?.Invoke(new LootLockerConnectionStateResponse
                 {
                     success = false,
-                    State = LootLockerConnectionState.SessionExpired,
+                    State = LootLockerConnectionState.ServerError,
                     statusCode = statusCode,
                     text = pingResponse.text,
                     errorData = pingResponse.errorData,


### PR DESCRIPTION
## Summary

Adds `CheckConnectionStatus` — a single public method that reports the current connection and session state for a player without requiring the developer to interpret raw HTTP status codes.

Implementation of https://github.com/lootlocker/index/issues/1574 for the Unity SDK

## How it works

1. **Fast local checks (no network call):**
   - SDK not initialized → `NotInitialized`
   - No session token in local state → `NotSignedIn`
   - `Application.internetReachability == NotReachable` → `NoConnection`

2. **Live check (ping):**
   - 200 → `SignedInAndConnected` (+ `ServerTime` populated)
   - 5xx → `ServerError`
   - 401 or 403 → calls `GetPlayerBanStatus` to disambiguate:
     - `is_banned == true` → `Banned` (+ `BanDetails` populated)
     - otherwise → `SessionExpired`
   - No response / timeout / status 0 → `NoConnection`

> Both 401 and 403 trigger the ban-status check because `allowTokenRefresh=true` can cause a ban-related 403 to auto-refresh, fail, and surface as a synthesized 401.

The method never attempts token refresh — it reports raw state so the developer can decide how to recover.

## API

```csharp
LootLockerSDKManager.CheckConnectionStatus(response =>
{
    switch (response.State)
    {
        case LootLockerConnectionState.SignedInAndConnected: /* all good */ break;
        case LootLockerConnectionState.NotSignedIn:         /* prompt login */ break;
        case LootLockerConnectionState.SessionExpired:      /* refresh or re-auth */ break;
        case LootLockerConnectionState.Banned:              /* show response.BanDetails */ break;
        case LootLockerConnectionState.NoConnection:        /* show offline UI */ break;
        case LootLockerConnectionState.ServerError:         /* retry later */ break;
        case LootLockerConnectionState.NotInitialized:      /* init SDK first */ break;
    }
}, forPlayerWithUlid: null); // optional, defaults to active player
```