### PR TITLE
Feat: Add "Check for updates" functionality to the SDK

### DIFF
--- a/Runtime/Editor/UpdateChecker.meta
+++ b/Runtime/Editor/UpdateChecker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cbb32737e67fa147a033cf8f1149adb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs
+++ b/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs
@@ -11,10 +11,10 @@ namespace LootLocker.Extension
     internal static class LootLockerUpdateChecker
     {
         // EditorPrefs keys — global per machine, not per project
-        private const string PrefNeverNotify    = "com.lootlocker.sdk.updatecheck.nevernotify";
-        private const string PrefSkippedVersion = "com.lootlocker.sdk.updatecheck.skippedversion";
-        private const string PrefRemindAfter    = "com.lootlocker.sdk.updatecheck.remindafter";
-        private const string PrefLastChecked    = "com.lootlocker.sdk.updatecheck.lastchecked";
+        internal const string PrefNeverNotify    = "com.lootlocker.sdk.updatecheck.nevernotify";
+        internal const string PrefSkippedVersion = "com.lootlocker.sdk.updatecheck.skippedversion";
+        internal const string PrefRemindAfter    = "com.lootlocker.sdk.updatecheck.remindafter";
+        internal const string PrefLastChecked    = "com.lootlocker.sdk.updatecheck.lastchecked";
 
         private const string GitHubReleasesUrl  = "https://api.github.com/repos/lootlocker/unity-sdk/releases/latest";
         private const double CheckIntervalHours = 24.0;
@@ -99,6 +99,7 @@ namespace LootLocker.Extension
 
             _isManualCheck = isManualCheck;
             _activeRequest = UnityWebRequest.Get(GitHubReleasesUrl);
+            _activeRequest.timeout = 15;
             _activeRequest.SetRequestHeader("User-Agent", "LootLocker Unity SDK Update Checker");
             _activeRequest.SendWebRequest();
             EditorApplication.update += PollRequest;
@@ -242,7 +243,12 @@ namespace LootLocker.Extension
             string[] parts = version.Split('.');
             int[] result = new int[parts.Length];
             for (int i = 0; i < parts.Length; i++)
-                int.TryParse(parts[i], out result[i]);
+            {
+                string part = parts[i];
+                int cut = part.IndexOfAny(new[] { '-', '+' });
+                if (cut >= 0) part = part.Substring(0, cut);
+                int.TryParse(part, out result[i]);
+            }
             return result;
         }
     }
@@ -269,7 +275,9 @@ namespace LootLocker.Extension
             EditorGUILayout.Space(10);
             EditorGUILayout.LabelField("LootLocker Unity SDK update available!", EditorStyles.boldLabel);
             EditorGUILayout.Space(4);
-            EditorGUILayout.LabelField($"Installed: v{_currentVersion}   \u2022   Latest: v{_latestVersion}");
+            string installed = string.IsNullOrEmpty(_currentVersion) ? "unknown" : $"v{_currentVersion}";
+            string latest    = string.IsNullOrEmpty(_latestVersion)  ? "unknown" : $"v{_latestVersion}";
+            EditorGUILayout.LabelField($"Installed: {installed}   \u2022   Latest: {latest}");
             EditorGUILayout.Space(6);
 
             if (GUILayout.Button("See What's New \u2197"))
@@ -286,19 +294,19 @@ namespace LootLocker.Extension
 
             if (GUILayout.Button("Skip This Version"))
             {
-                EditorPrefs.SetString("com.lootlocker.sdk.updatecheck.skippedversion", _latestVersion);
+                EditorPrefs.SetString(LootLockerUpdateChecker.PrefSkippedVersion, _latestVersion);
                 Close();
             }
 
             if (GUILayout.Button("Remind in 7 Days"))
             {
-                EditorPrefs.SetString("com.lootlocker.sdk.updatecheck.remindafter", DateTime.UtcNow.AddDays(7).Ticks.ToString());
+                EditorPrefs.SetString(LootLockerUpdateChecker.PrefRemindAfter, DateTime.UtcNow.AddDays(7).Ticks.ToString());
                 Close();
             }
 
             if (GUILayout.Button("Never Notify"))
             {
-                EditorPrefs.SetBool("com.lootlocker.sdk.updatecheck.nevernotify", true);
+                EditorPrefs.SetBool(LootLockerUpdateChecker.PrefNeverNotify, true);
                 Close();
             }
 

--- a/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs
+++ b/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs
@@ -1,0 +1,309 @@
+#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER && !LOOTLOCKER_DISABLE_EDITOR_EXTENSION
+using System;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace LootLocker.Extension
+{
+    [InitializeOnLoad]
+    internal static class LootLockerUpdateChecker
+    {
+        // EditorPrefs keys — global per machine, not per project
+        private const string PrefNeverNotify    = "com.lootlocker.sdk.updatecheck.nevernotify";
+        private const string PrefSkippedVersion = "com.lootlocker.sdk.updatecheck.skippedversion";
+        private const string PrefRemindAfter    = "com.lootlocker.sdk.updatecheck.remindafter";
+        private const string PrefLastChecked    = "com.lootlocker.sdk.updatecheck.lastchecked";
+
+        private const string GitHubReleasesUrl  = "https://api.github.com/repos/lootlocker/unity-sdk/releases/latest";
+        private const double CheckIntervalHours = 24.0;
+
+        private static UnityWebRequest _activeRequest;
+        private static bool _isManualCheck;
+
+        // How long to wait after editor startup before running the automatic update check.
+        // Gives heavy projects time to finish loading before a dialog appears.
+        // Does not affect manual checks via the menu item.
+        // Adjust here in source (range: 30–300 seconds is reasonable).
+        private const double StartupDelaySeconds = 180.0;
+        private static double _startupCheckTime = -1.0;
+
+        static LootLockerUpdateChecker()
+        {
+            // Delay initialization by the startup delay, then decide whether to check
+            // immediately or wait for the SDK version to be resolved.
+            _startupCheckTime = EditorApplication.timeSinceStartup + StartupDelaySeconds;
+            EditorApplication.update += WaitForStartupDelay;
+        }
+
+        private static void WaitForStartupDelay()
+        {
+            if (EditorApplication.timeSinceStartup < _startupCheckTime)
+                return;
+            EditorApplication.update -= WaitForStartupDelay;
+            _startupCheckTime = -1.0;
+
+            if (LootLockerConfig.SdkVersionDetermined)
+            {
+                TriggerPeriodicCheck();
+            }
+            else
+            {
+                LootLockerConfig.OnSdkVersionDetermined += OnSdkVersionDetermined;
+            }
+        }
+
+        private static void OnSdkVersionDetermined()
+        {
+            LootLockerConfig.OnSdkVersionDetermined -= OnSdkVersionDetermined;
+            TriggerPeriodicCheck();
+        }
+
+        private static void TriggerPeriodicCheck()
+        {
+            if (Application.isBatchMode)
+                return;
+
+            if (EditorPrefs.GetBool(PrefNeverNotify, false))
+                return;
+
+            long lastCheckedTicks = 0;
+            long.TryParse(EditorPrefs.GetString(PrefLastChecked, "0"), out lastCheckedTicks);
+            if (lastCheckedTicks > 0 && (DateTime.UtcNow - new DateTime(lastCheckedTicks, DateTimeKind.Utc)).TotalHours < CheckIntervalHours)
+                return;
+
+            FetchLatestRelease(isManualCheck: false);
+        }
+
+        [MenuItem("Window/LootLocker/Check for Updates", false, 102)]
+        public static void ManualCheck()
+        {
+            FetchLatestRelease(isManualCheck: true);
+        }
+
+        private static void FetchLatestRelease(bool isManualCheck)
+        {
+            if (_activeRequest != null)
+                return;
+
+            if (IsUpmManagedByRegistry())
+            {
+                if (isManualCheck)
+                    EditorUtility.DisplayDialog(
+                        "LootLocker Update Check",
+                        "This SDK is managed by the Unity Package Manager registry. Use the Package Manager window (Window \u2192 Package Manager) to check for and apply updates.",
+                        "OK");
+                return;
+            }
+
+            _isManualCheck = isManualCheck;
+            _activeRequest = UnityWebRequest.Get(GitHubReleasesUrl);
+            _activeRequest.SetRequestHeader("User-Agent", "LootLocker Unity SDK Update Checker");
+            _activeRequest.SendWebRequest();
+            EditorApplication.update += PollRequest;
+        }
+
+        private static bool IsUpmManagedByRegistry()
+        {
+            try
+            {
+                var pkg = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(LootLockerConfig).Assembly);
+                return pkg != null && pkg.source == PackageSource.Registry;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void PollRequest()
+        {
+            if (_activeRequest == null || !_activeRequest.isDone)
+                return;
+
+            EditorApplication.update -= PollRequest;
+
+#if UNITY_2020_1_OR_NEWER
+            bool failed = _activeRequest.result != UnityWebRequest.Result.Success;
+#else
+            bool failed = _activeRequest.isNetworkError || _activeRequest.isHttpError;
+#endif
+            string responseText = failed ? null : _activeRequest.downloadHandler.text;
+            _activeRequest.Dispose();
+            _activeRequest = null;
+
+            if (failed || string.IsNullOrEmpty(responseText))
+            {
+                if (_isManualCheck)
+                    EditorUtility.DisplayDialog(
+                        "LootLocker Update Check",
+                        "Could not reach GitHub to check for updates. Please try again later.",
+                        "OK");
+                // Don't stamp last-checked on network failure so the next editor open retries.
+                return;
+            }
+
+            string tagName = ExtractJsonStringValue(responseText, "tag_name");
+            string htmlUrl = ExtractJsonStringValue(responseText, "html_url");
+
+            if (string.IsNullOrEmpty(tagName))
+            {
+                if (_isManualCheck)
+                    EditorUtility.DisplayDialog(
+                        "LootLocker Update Check",
+                        "Could not parse release information. Visit https://github.com/lootlocker/unity-sdk/releases to check manually.",
+                        "OK");
+                // Don't stamp last-checked on parse failure so the next editor open retries.
+                return;
+            }
+
+            // Stamp last-checked now that we have a valid response.
+            EditorPrefs.SetString(PrefLastChecked, DateTime.UtcNow.Ticks.ToString());
+
+            string latestVersion = tagName.TrimStart('v');
+            string currentVersion = LootLockerConfig.current.sdk_version;
+            if (string.IsNullOrEmpty(currentVersion) || currentVersion.Equals("N/A", StringComparison.OrdinalIgnoreCase))
+                currentVersion = null;
+
+            if (!IsVersionNewer(latestVersion, currentVersion))
+            {
+                if (_isManualCheck)
+                {
+                    string displayCurrent = string.IsNullOrEmpty(currentVersion) ? "unknown" : $"v{currentVersion}";
+                    EditorUtility.DisplayDialog(
+                        "LootLocker Update Check",
+                        $"You are on the latest version ({displayCurrent}).",
+                        "OK");
+                }
+                return;
+            }
+
+            if (!_isManualCheck)
+            {
+                if (EditorPrefs.GetString(PrefSkippedVersion, "") == latestVersion)
+                    return;
+
+                long remindAfterTicks = 0;
+                long.TryParse(EditorPrefs.GetString(PrefRemindAfter, "0"), out remindAfterTicks);
+                if (remindAfterTicks > 0 && DateTime.UtcNow.Ticks < remindAfterTicks)
+                    return;
+            }
+
+            LootLockerUpdateNotificationWindow.Show(currentVersion, latestVersion, htmlUrl ?? GitHubReleasesUrl);
+        }
+
+        // Minimal JSON string-value extractor — avoids a full JSON parse for a single field.
+        // Finds the first occurrence of "key": "value" and returns the value.
+        private static string ExtractJsonStringValue(string json, string key)
+        {
+            string searchKey = "\"" + key + "\"";
+            int keyIndex = json.IndexOf(searchKey, StringComparison.Ordinal);
+            if (keyIndex < 0) return null;
+
+            int colonIndex = json.IndexOf(':', keyIndex + searchKey.Length);
+            if (colonIndex < 0) return null;
+
+            int quoteStart = json.IndexOf('"', colonIndex + 1);
+            if (quoteStart < 0) return null;
+
+            int quoteEnd = json.IndexOf('"', quoteStart + 1);
+            if (quoteEnd < 0) return null;
+
+            return json.Substring(quoteStart + 1, quoteEnd - quoteStart - 1);
+        }
+
+        // Returns true if candidate is strictly newer than current (numeric major.minor.patch comparison).
+        // If current is null/empty we can't confirm the user is up to date, so we return true
+        // (conservative: show the notification rather than silently skip).
+        internal static bool IsVersionNewer(string candidate, string current)
+        {
+            if (string.IsNullOrEmpty(candidate))
+                return false;
+
+            if (string.IsNullOrEmpty(current))
+                return true; // Unknown installed version — surface the notification.
+
+            int[] c   = ParseVersionParts(candidate);
+            int[] cur = ParseVersionParts(current);
+            int len = Math.Max(c.Length, cur.Length);
+            for (int i = 0; i < len; i++)
+            {
+                int cv   = i < c.Length   ? c[i]   : 0;
+                int curv = i < cur.Length ? cur[i] : 0;
+                if (cv > curv) return true;
+                if (cv < curv) return false;
+            }
+            return false;
+        }
+
+        private static int[] ParseVersionParts(string version)
+        {
+            string[] parts = version.Split('.');
+            int[] result = new int[parts.Length];
+            for (int i = 0; i < parts.Length; i++)
+                int.TryParse(parts[i], out result[i]);
+            return result;
+        }
+    }
+
+    internal class LootLockerUpdateNotificationWindow : EditorWindow
+    {
+        private string _currentVersion;
+        private string _latestVersion;
+        private string _releaseUrl;
+
+        internal static void Show(string currentVersion, string latestVersion, string releaseUrl)
+        {
+            var window = GetWindow<LootLockerUpdateNotificationWindow>(true, "LootLocker Update Available", true);
+            window._currentVersion = currentVersion;
+            window._latestVersion  = latestVersion;
+            window._releaseUrl     = releaseUrl;
+            window.minSize = new Vector2(480, 170);
+            window.maxSize = new Vector2(480, 170);
+            window.ShowUtility();
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.Space(10);
+            EditorGUILayout.LabelField("LootLocker Unity SDK update available!", EditorStyles.boldLabel);
+            EditorGUILayout.Space(4);
+            EditorGUILayout.LabelField($"Installed: v{_currentVersion}   \u2022   Latest: v{_latestVersion}");
+            EditorGUILayout.Space(6);
+
+            if (GUILayout.Button("See What's New \u2197"))
+                Application.OpenURL(_releaseUrl);
+
+            EditorGUILayout.Space(8);
+            EditorGUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Update Now"))
+            {
+                Application.OpenURL(_releaseUrl);
+                Close();
+            }
+
+            if (GUILayout.Button("Skip This Version"))
+            {
+                EditorPrefs.SetString("com.lootlocker.sdk.updatecheck.skippedversion", _latestVersion);
+                Close();
+            }
+
+            if (GUILayout.Button("Remind in 7 Days"))
+            {
+                EditorPrefs.SetString("com.lootlocker.sdk.updatecheck.remindafter", DateTime.UtcNow.AddDays(7).Ticks.ToString());
+                Close();
+            }
+
+            if (GUILayout.Button("Never Notify"))
+            {
+                EditorPrefs.SetBool("com.lootlocker.sdk.updatecheck.nevernotify", true);
+                Close();
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+    }
+}
+#endif

--- a/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs.meta
+++ b/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 05191ce48088b7a41b75fe8448e091c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs.meta
+++ b/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 05191ce48088b7a41b75fe8448e091c3

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -9672,6 +9672,7 @@ namespace LootLocker.Requests
         /// <list type="bullet">
         ///   <item><see cref="LootLockerConnectionState.NotInitialized"/> – the SDK has not been initialized.</item>
         ///   <item><see cref="LootLockerConnectionState.NotSignedIn"/> – no session exists for the player.</item>
+        ///   <item><see cref="LootLockerConnectionState.SavedButInactive"/> – the player has saved credentials but is not currently active in the multi-player session. Call the appropriate session start method or MakePlayerActive to activate them first.</item>
         ///   <item><see cref="LootLockerConnectionState.NoConnection"/> – the device has no internet or the server did not respond.</item>
         ///   <item><see cref="LootLockerConnectionState.SignedInAndConnected"/> – the session is valid and the server is reachable.</item>
         ///   <item><see cref="LootLockerConnectionState.SessionExpired"/> – a session exists but the token has expired (401) or another non-ban 403 was returned.</item>
@@ -9701,6 +9702,25 @@ namespace LootLocker.Requests
             if (string.IsNullOrEmpty(forPlayerWithUlid))
             {
                 forPlayerWithUlid = GetDefaultPlayerUlid();
+            }
+
+            // Only proceed if the player is currently active in the multi-player session.
+            // Using an inactive player's credentials would risk activating them as a side
+            // effect of a successful ping or an automatic token refresh.
+            bool isActive = !string.IsNullOrEmpty(forPlayerWithUlid) &&
+                            LootLockerStateData.GetActivePlayerULIDs().Any(u => string.Equals(u, forPlayerWithUlid, System.StringComparison.OrdinalIgnoreCase));
+            if (!isActive)
+            {
+                LootLockerConnectionState state = (!string.IsNullOrEmpty(forPlayerWithUlid) && LootLockerStateData.SaveStateExistsForPlayer(forPlayerWithUlid))
+                    ? LootLockerConnectionState.SavedButInactive
+                    : LootLockerConnectionState.NotSignedIn;
+                onComplete?.Invoke(new LootLockerConnectionStateResponse
+                {
+                    success = false,
+                    State = state,
+                    statusCode = 0,
+                });
+                return;
             }
 
             var playerData = LootLockerStateData.GetPlayerDataForPlayerWithUlidWithoutChangingState(forPlayerWithUlid);

--- a/Runtime/Game/Requests/MiscRequests.cs
+++ b/Runtime/Game/Requests/MiscRequests.cs
@@ -46,8 +46,10 @@ namespace LootLocker.Requests
         /// <summary>The SDK has not been initialized.</summary>
         NotInitialized,
         /// <summary>No session token exists for the specified player – they have not signed in.</summary>
-        NotSignedIn,
-        /// <summary>The session token is valid and the server is reachable.</summary>
+        NotSignedIn,        /// <summary>The player has saved credentials in local storage but is not currently active in the
+        /// multi-player session. Call the appropriate session start method or MakePlayerActive to activate
+        /// them before calling CheckConnectionStatus again.</summary>
+        SavedButInactive,        /// <summary>The session token is valid and the server is reachable.</summary>
         SignedInAndConnected,
         /// <summary>A session token exists but the server returned 401 – the token has expired.</summary>
         SessionExpired,

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -486,14 +486,41 @@ namespace LootLocker
 
         protected static ListRequest ListInstalledPackagesRequest;
 
+        // Raised once after the SDK version string has been resolved (either synchronously or
+        // after the async Client.List() call completes). Editor-only subscribers should
+        // unsubscribe inside their handler to avoid duplicate calls across domain reloads.
+        public static event Action OnSdkVersionDetermined;
+
+        // True once the SDK version has been resolved this editor session.
+        // Check this in [InitializeOnLoad] static constructors to handle the case where the
+        // event already fired before the subscriber registered (e.g. after a domain reload).
+        public static bool SdkVersionDetermined { get; private set; }
+
         static void StoreSDKVersion()
         {
-            if ((!string.IsNullOrEmpty(LootLockerConfig.current.sdk_version) && !LootLockerConfig.current.sdk_version.Equals("N/A")) 
-                || ListInstalledPackagesRequest != null
-                || Array.Exists(AssetDatabase.FindAssets($"{ConfigFileName} t:TextAsset"),
-                    g => AssetDatabase.GUIDToAssetPath(g).EndsWith($"/{ConfigFileName}{ConfigFileExtension}", StringComparison.OrdinalIgnoreCase)) /*Configured through config file, read sdk version there*/)
-            {
+            // Don't re-queue if a request is already in flight.
+            if (ListInstalledPackagesRequest != null)
                 return;
+            // Version provided by an external config file — treat as authoritative and
+            // don't overwrite it from the package manifest.
+            if (Array.Exists(AssetDatabase.FindAssets($"{ConfigFileName} t:TextAsset"),
+                g => AssetDatabase.GUIDToAssetPath(g).EndsWith($"/{ConfigFileName}{ConfigFileExtension}", StringComparison.OrdinalIgnoreCase)))
+            {
+                if (!SdkVersionDetermined)
+                {
+                    SdkVersionDetermined = true;
+                    OnSdkVersionDetermined?.Invoke();
+                }
+                return;
+            }
+            // If we already have a cached version, fire the event immediately for
+            // responsiveness so subscribers don't have to wait for Client.List().
+            // Then fall through to re-query — this keeps sdk_version current after
+            // SDK updates on disk (fixes stale version on upgrade).
+            if (!string.IsNullOrEmpty(LootLockerConfig.current.sdk_version) && !LootLockerConfig.current.sdk_version.Equals("N/A"))
+            {
+                SdkVersionDetermined = true;
+                OnSdkVersionDetermined?.Invoke();
             }
             ListInstalledPackagesRequest = Client.List();
             EditorApplication.update += ListInstalledPackagesRequestProgress;
@@ -517,6 +544,8 @@ namespace LootLocker
                     {
                         LootLockerConfig.current.sdk_version = package.version;
                         LootLockerLogger.Log($"SDK Version v{LootLockerConfig.current.sdk_version}", LootLockerLogger.LogLevel.Verbose);
+                        SdkVersionDetermined = true;
+                        OnSdkVersionDetermined?.Invoke();
                         return;
                     }
                 }
@@ -526,6 +555,8 @@ namespace LootLocker
                 {
                     LootLockerConfig.current.sdk_version = LootLockerJson.DeserializeObject<LLPackageDescription>(File.ReadAllText(sdkPackageJsonPath)).version;
                     LootLockerLogger.Log($"SDK Version v{LootLockerConfig.current.sdk_version}", LootLockerLogger.LogLevel.Verbose);
+                    SdkVersionDetermined = true;
+                    OnSdkVersionDetermined?.Invoke();
                     return;
                 }
 
@@ -539,12 +570,16 @@ namespace LootLocker
                         {
                             LootLockerConfig.current.sdk_version = packageDescription.version;
                             LootLockerLogger.Log($"SDK Version v{LootLockerConfig.current.sdk_version}", LootLockerLogger.LogLevel.Verbose);
+                            SdkVersionDetermined = true;
+                            OnSdkVersionDetermined?.Invoke();
                             return;
                         }
                     }
                 }
 
                 LootLockerConfig.current.sdk_version = "N/A";
+                SdkVersionDetermined = true;
+                OnSdkVersionDetermined?.Invoke();
             }
         }
 #endif

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -513,15 +513,10 @@ namespace LootLocker
                 }
                 return;
             }
-            // If we already have a cached version, fire the event immediately for
-            // responsiveness so subscribers don't have to wait for Client.List().
-            // Then fall through to re-query — this keeps sdk_version current after
-            // SDK updates on disk (fixes stale version on upgrade).
-            if (!string.IsNullOrEmpty(LootLockerConfig.current.sdk_version) && !LootLockerConfig.current.sdk_version.Equals("N/A"))
-            {
-                SdkVersionDetermined = true;
-                OnSdkVersionDetermined?.Invoke();
-            }
+            // If we already have a cached version, still re-query to keep sdk_version
+            // current after SDK updates on disk (fixes stale version on upgrade).
+            // We only raise OnSdkVersionDetermined once the authoritative value has
+            // been resolved by Client.List(), so subscribers never act on stale data.
             ListInstalledPackagesRequest = Client.List();
             EditorApplication.update += ListInstalledPackagesRequestProgress;
         }


### PR DESCRIPTION
## Summary

Adds an automatic SDK update checker to the Unity Editor, notifying developers when a newer version is available on GitHub Releases. Targets users who installed via `.unitypackage`, `.tgz`, or Git URL — UPM Registry installs are skipped since the Package Manager already handles update badges.

Closes #1603.

## Changes

### `Runtime/Game/Resources/LootLockerConfig.cs` (bugfix)
- **Fixes stale `sdk_version` after SDK upgrades on disk.** Previously `StoreSDKVersion()` early-outed when `sdk_version` was already populated, so the version was never refreshed after updating the SDK files. Now it fires `OnSdkVersionDetermined` immediately with the cached value for responsiveness, then always re-queues `Client.List()` to get the fresh authoritative version.
- Adds `public static bool SdkVersionDetermined` so `[InitializeOnLoad]` subscribers that register _after_ the event has already fired can still act on it without subscribing.
- Adds `public static event Action OnSdkVersionDetermined` — raised once each time the SDK version is resolved.

### `Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs` (feature)
- `[InitializeOnLoad]` static class `LootLockerUpdateChecker` with:
  - **Startup delay** (`StartupDelaySeconds = 180.0`, configurable in source) so the notification doesn't pop during heavy project loads.
  - After the delay: checks `SdkVersionDetermined` and either runs immediately or subscribes to `OnSdkVersionDetermined`.
  - **24 h throttle** — at most one automatic check per day, stamped in `EditorPrefs`.
  - **UPM Registry detection** via `PackageInfo.FindForAssembly` — skips automatic check, shows an informational dialog on manual check.
  - **Silence options** persisted in `EditorPrefs` (global per machine):
    - Skip This Version
    - Remind in 7 Days
    - Never Notify
- `[MenuItem("Window/LootLocker/Check for Updates")]` — manual trigger that bypasses throttle and silence settings.
- `LootLockerUpdateNotificationWindow` — small non-blocking `EditorWindow` showing installed vs. latest version with four action buttons.
- Version comparison is numeric major.minor.patch (not lexicographic).

## Looks

<img width="1138" height="778" alt="image" src="https://github.com/user-attachments/assets/d35eae27-f164-4fbd-85a3-190a395f7e27" />

<img width="1449" height="843" alt="image" src="https://github.com/user-attachments/assets/85fea48b-a12c-4b48-b96a-971e341b9c7b" />

## Testing

- Confirmed automatic check fires after startup delay with correct `sdk_version` resolved.
- Confirmed 24 h throttle suppresses duplicate checks within the same day.
- Confirmed manual check works regardless of throttle/silence state.
- UPM Registry install correctly skips auto-check.