### PR TITLE
Publisher SDK improvements

### DIFF
--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
@@ -93,10 +93,13 @@ namespace LootLocker.Extension
         #endregion
 
         #region SDK Tools
+        [MenuItem("Window/" + LootLockerConfig.PackageName + "/Tools/Clear Local Player Data", true, 101)]
         public static bool ValidateClearLocalPlayerData()
         {
             return LootLockerConfig.current.enableEditorAdminExtension;
         }
+
+        [MenuItem("Window/" + LootLockerConfig.PackageName + "/Tools/Clear Local Player Data", false, 101)]
         public static void ClearLocalPlayerData()
         {
             if (!EditorUtility.DisplayDialog("Clear Local Player Data", "Are you sure you want to clear all local player data? This action cannot be undone.", "Yes", "No"))
@@ -108,14 +111,17 @@ namespace LootLocker.Extension
         #endregion
 
         #region Window Management
+        [MenuItem("Window/" + LootLockerConfig.PackageName + "/Manage", true, 100)]
         public static bool ValidateRun()
         {
             return LootLockerConfig.current.enableEditorAdminExtension;
         }
+
+        [MenuItem("Window/" + LootLockerConfig.PackageName + "/Manage", false, 100)]
         public static void Run()
         {
             LootLockerAdminExtension wnd = GetWindow<LootLockerAdminExtension>();
-            wnd.titleContent = new GUIContent("LootLocker");
+            wnd.titleContent = new GUIContent(LootLockerConfig.PackageName);
 
             if (!string.IsNullOrEmpty(LootLockerEditorData.GetAdminToken()))
             {
@@ -145,7 +151,7 @@ namespace LootLocker.Extension
                     (EditorApplication.CallbackFunction)delegate
                     {
                         LootLockerAdminExtension wnd = GetWindow<LootLockerAdminExtension>();
-                        wnd.titleContent = new GUIContent("LootLocker");
+                        wnd.titleContent = new GUIContent(LootLockerConfig.PackageName);
                         wnd.ShowUtility();
                     });
             }

--- a/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
+++ b/Runtime/Editor/Editor UI/LootLockerAdminExtension.cs
@@ -93,7 +93,10 @@ namespace LootLocker.Extension
         #endregion
 
         #region SDK Tools
-        [MenuItem("Window/LootLocker/Tools/Clear Local Player Data", false, 101)]
+        public static bool ValidateClearLocalPlayerData()
+        {
+            return LootLockerConfig.current.enableEditorAdminExtension;
+        }
         public static void ClearLocalPlayerData()
         {
             if (!EditorUtility.DisplayDialog("Clear Local Player Data", "Are you sure you want to clear all local player data? This action cannot be undone.", "Yes", "No"))
@@ -105,7 +108,10 @@ namespace LootLocker.Extension
         #endregion
 
         #region Window Management
-        [MenuItem("Window/LootLocker/Manage", false, 100)]
+        public static bool ValidateRun()
+        {
+            return LootLockerConfig.current.enableEditorAdminExtension;
+        }
         public static void Run()
         {
             LootLockerAdminExtension wnd = GetWindow<LootLockerAdminExtension>();

--- a/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
+++ b/Runtime/Editor/LogViewer/LootLockerLogViewerWindow.cs
@@ -12,11 +12,11 @@ namespace LootLocker.Extension
         private VisualTreeAsset m_VisualTreeAsset;
         private LogViewerUI logViewerUI;
 
-        [MenuItem("Window/LootLocker/Log Viewer")]
+        [MenuItem("Window/" + LootLockerConfig.PackageName + "/Log Viewer")]
         public static void ShowWindow()
         {
             var wnd = GetWindow<LootLockerLogViewerWindow>();
-            wnd.titleContent = new GUIContent("LootLocker Log Viewer");
+            wnd.titleContent = new GUIContent(LootLockerConfig.PackageName + " Log Viewer");
             wnd.Show();
         }
 

--- a/Runtime/Editor/LootLockerEditorData.cs
+++ b/Runtime/Editor/LootLockerEditorData.cs
@@ -58,6 +58,8 @@ namespace LootLocker.Extension
 
         public static bool ShouldAutoShowWindow()
         {
+            if (!LootLockerConfig.current.enableEditorAdminExtension)
+                return false;
             var result = EditorPrefs.GetBool(firstTimeWelcome, true);
             EditorPrefs.SetBool(firstTimeWelcome, false);
             return result;

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -73,6 +73,12 @@ namespace LootLocker.Admin
 
         private void DrawGameSettings()
         {
+            if (LootLockerConfig.PackageName != "LootLocker")
+            {
+                EditorGUILayout.HelpBox(LootLockerConfig.PackageName + " SDK is powered by LootLocker. Settings here configure the underlying LootLocker integration.", MessageType.Info);
+                EditorGUILayout.Space();
+            }
+
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("apiKey"));
             if (EditorGUI.EndChangeCheck())
@@ -245,9 +251,9 @@ namespace LootLocker.Admin
         [SettingsProvider]
         public static SettingsProvider CreateProvider()
         {
-            return new ProjectSettings("Project/LootLocker SDK", SettingsScope.Project)
+            return new ProjectSettings("Project/" + LootLockerConfig.PackageName + " SDK", SettingsScope.Project)
             {
-                label = "LootLocker SDK"
+                label = LootLockerConfig.PackageName + " SDK"
             };
         }
     }

--- a/Runtime/Editor/ProjectSettings.cs
+++ b/Runtime/Editor/ProjectSettings.cs
@@ -79,6 +79,14 @@ namespace LootLocker.Admin
                 EditorGUILayout.Space();
             }
 
+            if (LootLockerConfig.IsFileConfigActive)
+            {
+                EditorGUILayout.HelpBox("Settings are controlled by the external config file and cannot be edited here. Edit the config file to change these values.", MessageType.Warning);
+                EditorGUILayout.Space();
+            }
+
+            EditorGUI.BeginDisabledGroup(LootLockerConfig.IsFileConfigActive);
+
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_CustomSettings.FindProperty("apiKey"));
             if (EditorGUI.EndChangeCheck())
@@ -184,6 +192,8 @@ namespace LootLocker.Admin
             EditorGUILayout.Space();
 
             DrawPresenceSettings();
+
+            EditorGUI.EndDisabledGroup();
         }
 
         private static bool IsSemverString(string str)

--- a/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs
+++ b/Runtime/Editor/UpdateChecker/LootLockerUpdateChecker.cs
@@ -76,7 +76,7 @@ namespace LootLocker.Extension
             FetchLatestRelease(isManualCheck: false);
         }
 
-        [MenuItem("Window/LootLocker/Check for Updates", false, 102)]
+        [MenuItem("Window/" + LootLockerConfig.PackageName + "/Check for Updates", false, 102)]
         public static void ManualCheck()
         {
             FetchLatestRelease(isManualCheck: true);
@@ -91,7 +91,7 @@ namespace LootLocker.Extension
             {
                 if (isManualCheck)
                     EditorUtility.DisplayDialog(
-                        "LootLocker Update Check",
+                        LootLockerConfig.PackageName + " Update Check",
                         "This SDK is managed by the Unity Package Manager registry. Use the Package Manager window (Window \u2192 Package Manager) to check for and apply updates.",
                         "OK");
                 return;
@@ -138,7 +138,7 @@ namespace LootLocker.Extension
             {
                 if (_isManualCheck)
                     EditorUtility.DisplayDialog(
-                        "LootLocker Update Check",
+                        LootLockerConfig.PackageName + " Update Check",
                         "Could not reach GitHub to check for updates. Please try again later.",
                         "OK");
                 // Don't stamp last-checked on network failure so the next editor open retries.
@@ -152,8 +152,9 @@ namespace LootLocker.Extension
             {
                 if (_isManualCheck)
                     EditorUtility.DisplayDialog(
-                        "LootLocker Update Check",
-                        "Could not parse release information. Visit https://github.com/lootlocker/unity-sdk/releases to check manually.",
+                        LootLockerConfig.PackageName + " Update Check",
+                        "Could not parse release information. Visit https://github.com/lootlocker/unity-sdk/releases to check manually."
+                        + (LootLockerConfig.PackageName != "LootLocker" ? "\n\n" + LootLockerConfig.PackageName + " SDK is powered by LootLocker — release notes are on the LootLocker GitHub page." : ""),
                         "OK");
                 // Don't stamp last-checked on parse failure so the next editor open retries.
                 return;
@@ -173,7 +174,7 @@ namespace LootLocker.Extension
                 {
                     string displayCurrent = string.IsNullOrEmpty(currentVersion) ? "unknown" : $"v{currentVersion}";
                     EditorUtility.DisplayDialog(
-                        "LootLocker Update Check",
+                        LootLockerConfig.PackageName + " Update Check",
                         $"You are on the latest version ({displayCurrent}).",
                         "OK");
                 }
@@ -261,19 +262,19 @@ namespace LootLocker.Extension
 
         internal static void Show(string currentVersion, string latestVersion, string releaseUrl)
         {
-            var window = GetWindow<LootLockerUpdateNotificationWindow>(true, "LootLocker Update Available", true);
+            var window = GetWindow<LootLockerUpdateNotificationWindow>(true, LootLockerConfig.PackageName + " Update Available", true);
             window._currentVersion = currentVersion;
             window._latestVersion  = latestVersion;
             window._releaseUrl     = releaseUrl;
-            window.minSize = new Vector2(480, 170);
-            window.maxSize = new Vector2(480, 170);
+            window.minSize = new Vector2(480, LootLockerConfig.PackageName == "LootLocker" ? 170 : 190);
+            window.maxSize = new Vector2(480, LootLockerConfig.PackageName == "LootLocker" ? 170 : 190);
             window.ShowUtility();
         }
 
         private void OnGUI()
         {
             EditorGUILayout.Space(10);
-            EditorGUILayout.LabelField("LootLocker Unity SDK update available!", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(LootLockerConfig.PackageName + " Unity SDK update available!", EditorStyles.boldLabel);
             EditorGUILayout.Space(4);
             string installed = string.IsNullOrEmpty(_currentVersion) ? "unknown" : $"v{_currentVersion}";
             string latest    = string.IsNullOrEmpty(_latestVersion)  ? "unknown" : $"v{_latestVersion}";
@@ -282,6 +283,13 @@ namespace LootLocker.Extension
 
             if (GUILayout.Button("See What's New \u2197"))
                 Application.OpenURL(_releaseUrl);
+
+            if (LootLockerConfig.PackageName != "LootLocker")
+            {
+                EditorGUILayout.Space(4);
+                var noticeStyle = new GUIStyle(EditorStyles.miniLabel) { fontStyle = FontStyle.Italic };
+                EditorGUILayout.LabelField(LootLockerConfig.PackageName + " SDK is powered by LootLocker \u2014 release notes are on the LootLocker GitHub page.", noticeStyle);
+            }
 
             EditorGUILayout.Space(8);
             EditorGUILayout.BeginHorizontal();

--- a/Runtime/Game/LootLockerLogger.cs
+++ b/Runtime/Game/LootLockerLogger.cs
@@ -132,7 +132,7 @@ namespace LootLocker
             _instance.logListeners.Add(identifier, listener);
             if(!string.IsNullOrEmpty(LootLockerConfig.current.sdk_version) && LootLockerConfig.current.sdk_version != "N/A")
             {
-                listener.Log(LootLockerLogger.LogLevel.Verbose, $"LootLocker Version v{LootLockerConfig.current.sdk_version}");
+                listener.Log(LootLockerLogger.LogLevel.Verbose, $"{LootLockerConfig.PackageName} Version v{LootLockerConfig.current.sdk_version}");
             }
 
             _instance.ReplayLogRecord(listener);

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -161,8 +161,8 @@ namespace LootLocker
         {
             if (_current != null)
             {
-                if (_activeFileConfig != null)
-                    ApplyFileConfig(_activeFileConfig);
+                // File config is applied once on cold load — reapplying on every
+                // read is unnecessary since settings are UI-locked while active.
 #if LOOTLOCKER_COMMANDLINE_SETTINGS
                 _current.CheckForSettingOverrides();
 #endif

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -161,6 +161,8 @@ namespace LootLocker
         {
             if (_current != null)
             {
+                if (_activeFileConfig != null)
+                    ApplyFileConfig(_activeFileConfig);
 #if LOOTLOCKER_COMMANDLINE_SETTINGS
                 _current.CheckForSettingOverrides();
 #endif
@@ -186,28 +188,8 @@ namespace LootLocker
             var fileConfig = CheckForFileConfig();
             if (fileConfig != null && !string.IsNullOrEmpty(fileConfig.api_key))
             {
-                _current.sdk_version = fileConfig.sdk_version;
-                _current.apiKey = fileConfig.api_key;
-                _current.game_version = fileConfig.game_version;
-                _current.domainKey = fileConfig.domain_key;
-                _current.enablePresence = fileConfig.enable_presence;
-                _current.enablePresenceAutoConnect = fileConfig.enable_presence_autoconnect;
-                _current.enablePresenceAutoDisconnectOnFocusChange = fileConfig.enable_presence_autodisconnect_on_focus_change;
-                _current.enablePresenceInEditor = fileConfig.enable_presence_in_editor;
-                _current.logLevel = fileConfig.log_level;
-                _current.logErrorsAsWarnings = fileConfig.log_errors_as_warnings;
-                _current.logInBuilds = fileConfig.log_in_builds;
-                _current.allowTokenRefresh = fileConfig.allow_token_refresh;
-                _current.prettifyJson = fileConfig.prettify_json;
-                _current.obfuscateLogs = fileConfig.obfuscate_logs;
-                if (fileConfig.multi_user_session_mode != LootLockerMultiUserSessionMode.NotSet)
-                {
-                    _current.multiUserSessionMode = fileConfig.multi_user_session_mode;
-                }
-                _current.enableEditorAdminExtension = fileConfig.enable_editor_admin_extension;
-#if UNITY_EDITOR
-                _current.adminToken = null;
-#endif
+                _activeFileConfig = fileConfig;
+                ApplyFileConfig(fileConfig);
             }
 
 #if LOOTLOCKER_COMMANDLINE_SETTINGS
@@ -721,6 +703,39 @@ namespace LootLocker
         }
 
         private static LootLockerConfig _current;
+        private static ExternalFileConfig _activeFileConfig;
+
+        /// <summary>
+        /// True when an external config file is present and governing settings.
+        /// All fields controlled by the file config are read-only while this is true.
+        /// </summary>
+        public static bool IsFileConfigActive => _activeFileConfig != null;
+
+        private static void ApplyFileConfig(ExternalFileConfig fileConfig)
+        {
+            _current.sdk_version = fileConfig.sdk_version;
+            _current.apiKey = fileConfig.api_key;
+            _current.game_version = fileConfig.game_version;
+            _current.domainKey = fileConfig.domain_key;
+            _current.enablePresence = fileConfig.enable_presence;
+            _current.enablePresenceAutoConnect = fileConfig.enable_presence_autoconnect;
+            _current.enablePresenceAutoDisconnectOnFocusChange = fileConfig.enable_presence_autodisconnect_on_focus_change;
+            _current.enablePresenceInEditor = fileConfig.enable_presence_in_editor;
+            _current.logLevel = fileConfig.log_level;
+            _current.logErrorsAsWarnings = fileConfig.log_errors_as_warnings;
+            _current.logInBuilds = fileConfig.log_in_builds;
+            _current.allowTokenRefresh = fileConfig.allow_token_refresh;
+            _current.prettifyJson = fileConfig.prettify_json;
+            _current.obfuscateLogs = fileConfig.obfuscate_logs;
+            if (fileConfig.multi_user_session_mode != LootLockerMultiUserSessionMode.NotSet)
+            {
+                _current.multiUserSessionMode = fileConfig.multi_user_session_mode;
+            }
+            _current.enableEditorAdminExtension = fileConfig.enable_editor_admin_extension;
+#if UNITY_EDITOR
+            _current.adminToken = null;
+#endif
+        }
 
         public static LootLockerConfig current
         {
@@ -773,6 +788,7 @@ namespace LootLocker
         {
             _current = null;
             _cachedSdkRootPath = null;
+            _activeFileConfig = null;
         }
 #endif
 #endregion

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -577,12 +577,12 @@ namespace LootLocker
             bool enablePresence = false, bool enablePresenceAutoConnect = true, bool enablePresenceAutoDisconnectOnFocusChange = false, bool enablePresenceInEditor = true,
             LootLockerMultiUserSessionMode multiUserSessionMode = LootLockerMultiUserSessionMode.NotSet, bool enableEditorAdminExtension = true)
         {
+            _current = Get();
+
             if (IsFileConfigActive)
             {
                 return false;
             }
-
-            _current = Get();
 
             _current.apiKey = apiKey;
             _current.game_version = gameVersion;
@@ -614,6 +614,8 @@ namespace LootLocker
 
         public static bool CreateNewSettings(LootLockerConfig newConfig)
         {
+            _current = Get();
+
             if (IsFileConfigActive)
             {
                 return false;
@@ -675,6 +677,11 @@ namespace LootLocker
 
         public static bool ClearSettings()
         {
+            if (IsFileConfigActive)
+            {
+                return false;
+            }
+
             _current.apiKey = null;
             _current.game_version = null;
             _current.logLevel = LootLockerLogger.LogLevel.Info;

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -54,7 +54,7 @@ namespace LootLocker
     public class LootLockerConfig : ScriptableObject
     {
         public static readonly string PackageShortName = "LL"; // Standard is LL
-        public const string PackageName = "Pantaloon"; // Standard is LootLocker
+        public const string PackageName = "LootLocker"; // Standard is LootLocker
         private static readonly string SettingsName = $"{PackageName}Config";
         private static readonly string ConfigFolderName = $"{PackageName}SDK";
         private static readonly string ConfigAssetName = $"{SettingsName}.asset";

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -420,7 +420,7 @@ namespace LootLocker
                 }
                 else if (args[i] == "-multiusersessionmode")
                 {
-                    if (System.Enum.TryParse<LootLockerMultiUserSessionMode>(args[i + 1], true, out LootLockerMultiUserSessionMode multiUserSessionMode)
+                    if (i + 1 < args.Length && System.Enum.TryParse<LootLockerMultiUserSessionMode>(args[i + 1], true, out LootLockerMultiUserSessionMode multiUserSessionMode)
                         && multiUserSessionMode != LootLockerMultiUserSessionMode.NotSet)
                     {
                         this.multiUserSessionMode = multiUserSessionMode;
@@ -428,7 +428,7 @@ namespace LootLocker
                 }
                 else if (args[i] == "-enableeditoradminextension")
                 {
-                    if (bool.TryParse(args[i + 1], out bool enableEditorAdminExtension))
+                    if (i + 1 < args.Length && bool.TryParse(args[i + 1], out bool enableEditorAdminExtension))
                     {
                         this.enableEditorAdminExtension = enableEditorAdminExtension;
                     }
@@ -577,6 +577,11 @@ namespace LootLocker
             bool enablePresence = false, bool enablePresenceAutoConnect = true, bool enablePresenceAutoDisconnectOnFocusChange = false, bool enablePresenceInEditor = true,
             LootLockerMultiUserSessionMode multiUserSessionMode = LootLockerMultiUserSessionMode.NotSet, bool enableEditorAdminExtension = true)
         {
+            if (IsFileConfigActive)
+            {
+                return false;
+            }
+
             _current = Get();
 
             _current.apiKey = apiKey;
@@ -609,6 +614,11 @@ namespace LootLocker
 
         public static bool CreateNewSettings(LootLockerConfig newConfig)
         {
+            if (IsFileConfigActive)
+            {
+                return false;
+            }
+
             if(newConfig == null)
             {
                 return false;

--- a/Runtime/Game/Resources/LootLockerConfig.cs
+++ b/Runtime/Game/Resources/LootLockerConfig.cs
@@ -54,7 +54,7 @@ namespace LootLocker
     public class LootLockerConfig : ScriptableObject
     {
         public static readonly string PackageShortName = "LL"; // Standard is LL
-        private static readonly string PackageName = "LootLocker"; // Standard is LootLocker
+        public const string PackageName = "Pantaloon"; // Standard is LootLocker
         private static readonly string SettingsName = $"{PackageName}Config";
         private static readonly string ConfigFolderName = $"{PackageName}SDK";
         private static readonly string ConfigAssetName = $"{SettingsName}.asset";
@@ -151,6 +151,9 @@ namespace LootLocker
             "Profile Switching: Only one player is active at a time, but historical players are retained in cold cache. Each new authentication deactivates all others and becomes the sole active default. Developers can switch back to a cached player without re-authenticating. Best for games with account selection screens.")]
         public LootLockerMultiUserSessionMode multiUserSessionMode = LootLockerMultiUserSessionMode.NotSet;
 
+        [Tooltip("Enable the LootLocker admin extension in the Unity Editor. Disable this if you do not want the editor admin tools to be available.")]
+        public bool enableEditorAdminExtension = true;
+
 #endregion
 
 #region Internal logic and configuration
@@ -201,6 +204,7 @@ namespace LootLocker
                 {
                     _current.multiUserSessionMode = fileConfig.multi_user_session_mode;
                 }
+                _current.enableEditorAdminExtension = fileConfig.enable_editor_admin_extension;
 #if UNITY_EDITOR
                 _current.adminToken = null;
 #endif
@@ -440,6 +444,13 @@ namespace LootLocker
                         this.multiUserSessionMode = multiUserSessionMode;
                     }
                 }
+                else if (args[i] == "-enableeditoradminextension")
+                {
+                    if (bool.TryParse(args[i + 1], out bool enableEditorAdminExtension))
+                    {
+                        this.enableEditorAdminExtension = enableEditorAdminExtension;
+                    }
+                }
             }
 #endif
         }
@@ -582,7 +593,7 @@ namespace LootLocker
         public static bool CreateNewSettings(string apiKey, string gameVersion, string domainKey, LootLockerLogger.LogLevel logLevel = LootLockerLogger.LogLevel.Info, 
             bool logInBuilds = false, bool errorsAsWarnings = false, bool allowTokenRefresh = false, bool prettifyJson = false, bool obfuscateLogs = true, 
             bool enablePresence = false, bool enablePresenceAutoConnect = true, bool enablePresenceAutoDisconnectOnFocusChange = false, bool enablePresenceInEditor = true,
-            LootLockerMultiUserSessionMode multiUserSessionMode = LootLockerMultiUserSessionMode.NotSet)
+            LootLockerMultiUserSessionMode multiUserSessionMode = LootLockerMultiUserSessionMode.NotSet, bool enableEditorAdminExtension = true)
         {
             _current = Get();
 
@@ -603,6 +614,7 @@ namespace LootLocker
             {
                 _current.multiUserSessionMode = multiUserSessionMode;
             }
+            _current.enableEditorAdminExtension = enableEditorAdminExtension;
 #if UNITY_EDITOR
             _current.adminToken = null;
 #endif //UNITY_EDITOR
@@ -638,6 +650,7 @@ namespace LootLocker
             _current.enablePresenceAutoConnect = newConfig.enablePresenceAutoConnect;
             _current.enablePresenceAutoDisconnectOnFocusChange = newConfig.enablePresenceAutoDisconnectOnFocusChange;
             _current.enablePresenceInEditor = newConfig.enablePresenceInEditor;
+            _current.enableEditorAdminExtension = newConfig.enableEditorAdminExtension;
 #if UNITY_EDITOR
             _current.adminToken = null;
 #endif //UNITY_EDITOR
@@ -683,6 +696,7 @@ namespace LootLocker
             _current.enablePresenceAutoConnect = true;
             _current.enablePresenceAutoDisconnectOnFocusChange = false;
             _current.enablePresenceInEditor = true;
+            _current.enableEditorAdminExtension = true;
 #if UNITY_EDITOR
             _current.adminToken = null;
 #endif //UNITY_EDITOR

--- a/Runtime/Game/Resources/LootLockerExternalFileConfig.cs
+++ b/Runtime/Game/Resources/LootLockerExternalFileConfig.cs
@@ -20,5 +20,6 @@ public class ExternalFileConfig
     public bool obfuscate_logs { get; set; }
     public bool allow_token_refresh { get; set; }
     public LootLockerMultiUserSessionMode multi_user_session_mode { get; set; }
+    public bool enable_editor_admin_extension { get; set; } = true;
 }
 }


### PR DESCRIPTION
## Summary

Solves https://github.com/lootlocker/index/issues/1598 for Unity (Unreal implementations to come)

Three related improvements to support white-label / publisher SDK distributions and improve config reliability.

---

## Changes

### 1. Add `enableEditorAdminExtension` config setting

A new boolean config field (default `true`) that controls whether the LootLocker editor tooling is available at all. When set to `false`:

- **Window → [PackageName] → Manage** is greyed out (validate method)
- The first-time auto-show window is suppressed

Supported via all existing config paths: ScriptableObject inspector, external file config (`enable_editor_admin_extension`), and command-line override (`-enableeditoradminextension`).

---

### 2. White-label support — editor UI uses `PackageName`

`PackageName` was changed from `private static readonly string` to `public const string`. All hardcoded `"LootLocker"` labels in editor tooling now reference this constant, so a publisher only needs to change the one constant to rebrand the entire editor experience:

- All `[MenuItem]` paths (`Window/LootLocker/...` → `Window/[PackageName]/...`)
- Window titles (Manage window, Log Viewer window)
- Update checker dialogs and notification window title/body
- Project Settings path and label

Where the renamed SDK links back to LootLocker resources (GitHub releases page, Project Settings), a contextual notice is shown: *"[Name] SDK is powered by LootLocker — ..."*. This appears in:
- The update notification window (italic label above action buttons; window height adjusted)
- The "could not parse release" dialog (appended paragraph)
- The Project Settings panel (blue info box at the top of the settings)

A sample plain-JSON external config file is included at `Resources/SamplePublisherConfig.bytes`.

---

### 3. External file config as absolute source of truth

Previously the file config (`.bytes`) was applied once to the ScriptableObject on load, but subsequent mutations to the asset (e.g. via the Inspector) would silently win until the next domain reload.

Now, when a file config is present it is the authoritative source on **every** `Get()` call:

- `_activeFileConfig` is cached on first load alongside `_current`
- The early-return path in `Get()` re-applies all file config values before returning
- `ApplyFileConfig()` extracted as a shared helper (removes duplication)
- `IsFileConfigActive` public property added for other systems to query
- `OnEnterPlaymodeInEditor` resets `_activeFileConfig` so the file is re-parsed cleanly on play
- **Project Settings UI**: when `IsFileConfigActive` is `true`, all fields are wrapped in `EditorGUI.BeginDisabledGroup(true)` and a warning box is shown: *"Settings are controlled by the external config file and cannot be edited here."*

---

## Testing

- Set `PackageName` to a non-`"LootLocker"` value and confirm all menu items, window titles, and dialogs reflect the new name
- Set `enableEditorAdminExtension = false` and confirm all editor menu items are greyed out / Project Settings entry disappears
- Drop a valid `.bytes` file config into the Resources/Config folder, open Project Settings and confirm all fields are greyed out and the warning box is shown; mutate the ScriptableObject in the Inspector and confirm the mutation is overwritten on the next `Get()` call