### PR TITLE
meta: Create workflows to automate release process

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  issues: write
 
 jobs:
   create-release:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,169 @@
+name: Create Release
+run-name: "Create Release from ${{ github.ref_name }}"
+
+on:
+  workflow_run:
+    workflows: ["Run Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to pull release notes from (e.g. 123)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Find merged PR that triggered this push (or use dispatch input)
+        id: find-pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            echo "Manual dispatch — fetching PR #${PR_NUMBER}"
+          else
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            echo "Looking up PR for commit ${HEAD_SHA}"
+            PR_NUMBER=$(gh pr list \
+              --search "${HEAD_SHA}" \
+              --state merged \
+              --json number \
+              --limit 1 \
+              --jq '.[0].number')
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No PR found. Not a release-eligible push."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json number,body,labels,title,state --jq '.')
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          HAS_RC_LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | index("release candidate") != null')
+          PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+
+          echo "Found PR #${PR_NUMBER}: ${PR_TITLE} (state: ${PR_STATE})"
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_RC_LABEL" != "true" ]; then
+            echo "::notice::PR #${PR_NUMBER} does not have 'release candidate' label. Skipping release."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Write PR body to temp file for safe handling later
+          echo "$PR_JSON" | jq -r '.body' > /tmp/pr-body.md
+          echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate release notes (PR body is non-empty)
+        id: validate
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          if [ ! -s /tmp/pr-body.md ]; then
+            echo "::error::PR body is empty. Release notes are required in the PR description."
+            exit 1
+          fi
+          echo "Release notes found ($(wc -c < /tmp/pr-body.md) bytes)."
+
+      - name: Read version from package.json
+        id: version
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::Could not read version from package.json"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          TAG="v${VERSION}"
+          echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION} → Tag: ${TAG}"
+
+      - name: Check tag doesn't already exist
+        id: check-tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists. Version must be bumped."
+            exit 1
+          fi
+          echo "Tag ${TAG} is available."
+
+      - name: Validate version bump against latest tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+
+          # Simple semver comparison (handles X.Y.Z format)
+          compare_versions() {
+            echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'
+          }
+
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version $NEW_VERSION is not greater than latest release $LATEST_VERSION. Version must be bumped."
+            exit 1
+          fi
+          echo "Version bump validated: ${LATEST_VERSION} → ${NEW_VERSION}"
+
+      - name: Create git tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed tag ${TAG}"
+
+      - name: Create GitHub Release
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          TITLE="LootLocker_UnitySDKv${VERSION}"
+
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes-file /tmp/pr-body.md \
+            --target main
+
+          echo "Created release ${TAG}"
+
+      - name: Post release notification on PR
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          PR_NUMBER="${{ steps.find-pr.outputs.PR_NUMBER }}"
+          REPO="${{ github.repository }}"
+
+          printf -v BODY '✅ **Release [%s](https://github.com/%s/releases/tag/%s) created.**\n\nWorkflows now running:\n- [Package SDK](https://github.com/%s/actions/workflows/package-sdk.yml) — builds and attaches .unitypackage\n- [Sign Package](https://github.com/%s/actions/workflows/sign-package.yml) — signs and attaches UPM package\n- [Generate Docs](https://github.com/%s/actions/workflows/generate-docs.yml) — deploys reference docs' \
+            "$TAG" "$REPO" "$TAG" "$REPO" "$REPO" "$REPO"
+
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -1,0 +1,149 @@
+name: Enforce Release PR
+run-name: "Enforce release candidate PR requirements"
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enforce:
+    name: Validate release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: contains(github.event.pull_request.labels.*.name, 'release candidate')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate PR body structure
+        id: check-body
+        run: |
+          BODY="${{ github.event.pull_request.body }}"
+
+          # Check 1: Non-empty
+          if [ -z "$(echo "$BODY" | tr -d '[:space:]')" ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            echo "BODY_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "BODY_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check 2: At least one ### section header
+          if echo "$BODY" | grep -q '^### '; then
+            echo "HAS_SECTIONS=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::PR body must have at least one section header (### Features, ### Fixes, etc.)."
+            echo "HAS_SECTIONS=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check 3: Full Changelog link (warning only)
+          if echo "$BODY" | grep -qi 'Full Changelog:'; then
+            echo "HAS_CHANGELOG_LINK=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PR body is missing a 'Full Changelog:' compare link."
+            echo "HAS_CHANGELOG_LINK=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::Could not read version from package.json"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version in branch: ${VERSION}"
+
+      - name: Get latest release tag
+        id: latest-tag
+        run: |
+          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "v0.0.0"')
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Latest release tag: ${LATEST_TAG}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate version bump
+        id: check-version
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          LATEST_TAG="${{ steps.latest-tag.outputs.TAG }}"
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+
+          compare_versions() {
+            echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'
+          }
+
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version ${NEW_VERSION} is not greater than latest release ${LATEST_VERSION}."
+            echo "VERSION_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version bump OK: ${LATEST_VERSION} → ${NEW_VERSION}"
+            echo "VERSION_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report and post status comment
+        if: always()
+        run: |
+          VERSION_OK="${{ steps.check-version.outputs.VERSION_OK }}"
+          BODY_OK="${{ steps.check-body.outputs.BODY_OK }}"
+          HAS_SECTIONS="${{ steps.check-body.outputs.HAS_SECTIONS }}"
+          HAS_CHANGELOG_LINK="${{ steps.check-body.outputs.HAS_CHANGELOG_LINK }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          issues=""
+          if [ "$VERSION_OK" != "true" ]; then
+            issues="${issues}\\n- ⚠️ **Version not bumped.** Latest release is ${{ steps.latest-tag.outputs.TAG }} but this PR has v${VERSION}."
+          fi
+          if [ "$BODY_OK" != "true" ]; then
+            issues="${issues}\\n- ⚠️ **PR body is empty.** Add release notes to the PR description."
+          fi
+          if [ "$HAS_SECTIONS" != "true" ]; then
+            issues="${issues}\\n- ⚠️ **No section headers found.** Add at least one \`###\` section (e.g. \`### Features\`, \`### Fixes\`)."
+          fi
+
+          warnings=""
+          if [ "$HAS_CHANGELOG_LINK" != "true" ]; then
+            warnings="${warnings}\\n- 💡 Missing \`Full Changelog:\` compare link — consider adding one."
+          fi
+
+          if [ -n "$issues" ]; then
+            printf "### ❌ Release PR Validation Failed\n${issues}${warnings}\n" > /tmp/status.md
+          else
+            printf "### ✅ Release PR Validation Passed\n\n- Version: **v${VERSION}** (bumped from ${{ steps.latest-tag.outputs.TAG }})\n- Release notes: present (section headers found)" > /tmp/status.md
+            if [ "$HAS_CHANGELOG_LINK" = "true" ]; then
+              printf ", changelog link present" >> /tmp/status.md
+            fi
+            printf "\n" >> /tmp/status.md
+          fi
+
+          # Find and update existing validation comments, or create a new one
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("### ✅ Release PR Validation") or startswith("### ❌ Release PR Validation")) | .id' \
+            | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              --field body="$(cat /tmp/status.md)"
+          else
+            gh pr comment "$PR_NUMBER" --body "$(cat /tmp/status.md)"
+          fi
+
+          if [ -n "$issues" ]; then
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   enforce:
@@ -26,7 +27,7 @@ jobs:
       - name: Validate PR body structure
         id: check-body
         run: |
-          BODY="${{ github.event.pull_request.body }}"
+          BODY=$(jq -r '.pull_request.body // ""' < "$GITHUB_EVENT_PATH")
 
           # Check 1: Non-empty
           if [ -z "$(echo "$BODY" | tr -d '[:space:]')" ]; then

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,191 @@
+name: Open Release PR
+run-name: "Open release candidate PR for ${{ inputs.bump }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Type of version bump
+        required: true
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+        default: auto
+      custom_version:
+        description: Custom version override (e.g. 8.1.0). Leave empty to use semver bump.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-pr:
+    name: Create release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Read current version
+        id: current
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version: ${VERSION}"
+
+      - name: Get previous release tag and commit log
+        id: prev-tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${LATEST_TAG:-none}"
+
+          # Collect commits since last tag (or all commits if no tag yet)
+          REV_RANGE=""
+          if [ -n "$LATEST_TAG" ]; then
+            REV_RANGE="${LATEST_TAG}..HEAD"
+          else
+            REV_RANGE="HEAD"
+          fi
+
+          git log "$REV_RANGE" --format="%s" > /tmp/commits.log
+          COMMIT_COUNT=$(wc -l < /tmp/commits.log)
+          echo "Commits: ${COMMIT_COUNT}"
+          echo "COMMIT_COUNT=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate new version
+        id: new-version
+        run: |
+          CURRENT="${{ steps.current.outputs.VERSION }}"
+          CUSTOM="${{ inputs.custom_version }}"
+          BUMP="${{ inputs.bump }}"
+          ALREADY_CALCULATED=false
+
+          if [ -n "$CUSTOM" ]; then
+            NEW="$CUSTOM"
+            echo "Using custom version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
+            echo "Auto-detecting version from OpenRouter..."
+            if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
+              exit 1
+            fi
+            COMMITS=$(head -100 /tmp/commits.log)
+            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 9.0.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [ -z "$NEW" ]; then
+              echo "::warning::AI returned no parseable version, falling back to patch bump."
+              PATCH=$(echo "$CURRENT" | cut -d. -f3)
+              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
+            fi
+            echo "AI suggested version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$ALREADY_CALCULATED" = "false" ]; then
+            BUMP="${{ inputs.bump }}"
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+            NEW="${MAJOR}.${MINOR}.${PATCH}"
+            echo "Bumped ${CURRENT} -> ${NEW} (${BUMP})"
+          fi
+
+          echo "TAG=v${NEW}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${NEW}" >> "$GITHUB_OUTPUT"
+
+
+      - name: Update version in package.json
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          jq --arg v "$NEW_VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          echo "Updated package.json version to ${NEW_VERSION}"
+
+      - name: Create branch and commit
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          BRANCH="release/v${NEW_VERSION}"
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git checkout -b "$BRANCH"
+          git add package.json
+          git commit -m "Bump version to ${NEW_VERSION}"
+          git push origin "$BRANCH"
+
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
+
+      - name: Generate release notes
+        run: |
+          PREV="${{ steps.prev-tag.outputs.TAG }}"
+          NEW_TAG="${{ steps.new-version.outputs.TAG }}"
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          COMMITS=$(cat /tmp/commits.log)
+
+          echo "::group::Commits since ${PREV:-beginning}"
+          echo "$COMMITS"
+          echo "::endgroup::"
+
+          if [ -n "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+            echo "Generating release notes via OpenRouter..."
+            printf 'You are writing release notes for LootLocker Unity SDK version %s.\n\nBelow are the commit messages since the last release. Write concise, user-facing release notes following this template exactly. Only include sections that have content. Keep the audience in mind: game developers using LootLocker in Unity.\n\nTemplate:\n### Features\n- Feature Title - Description of what the developer can now do.\n\n### Fixes\n- Fixed an issue where X would happen when Y.\n\n### Breaking Changes\n- Removed / changed API - explain migration.\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unity-sdk/compare/%s...%s)\n\nCommit messages:\n%s\n' "$NEW_VERSION" "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" "$COMMITS" > /tmp/ai-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/ai-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"medium"},max_tokens:8000,temperature:0.3}')")
+            NOTES=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""')
+            if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then
+              echo "$NOTES" > /tmp/release-notes.md
+              echo "AI-generated release notes."
+            else
+              echo "::warning::OpenRouter returned empty response, falling back to template."
+              NOTES=""
+            fi
+          fi
+
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Using static template."
+            printf '### Features\n\n- Feature Title - Description.\n\n### Fixes\n\n- Fixed ...\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unity-sdk/compare/%s...%s)\n' "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" > /tmp/release-notes.md
+          fi
+
+          echo "Release notes generated."
+
+      - name: Create PR
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          TITLE="Release v${NEW_VERSION}"
+
+          gh pr create \
+            --title "$TITLE" \
+            --body "$(cat /tmp/release-notes.md)" \
+            --base main \
+            --head "$BRANCH" \
+            --label "release candidate" \
+            --reviewer "kirre-bylund"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/package-sdk.yml
+++ b/.github/workflows/package-sdk.yml
@@ -60,6 +60,7 @@ jobs:
           githubToken: ${{ SECRETS.GITHUB_TOKEN }}
 
       - name: Attach .unitypackage to release
+        if: github.event_name == 'release'
         run: |
           for f in unity-sdk-packager/LootLockerSDK*.unitypackage; do
             echo "Uploading $f"

--- a/.github/workflows/package-sdk.yml
+++ b/.github/workflows/package-sdk.yml
@@ -1,0 +1,76 @@
+name: Package SDK
+run-name: "Package SDK for ${{ github.ref_name }}"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  package-sdk:
+    name: Package and attach SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        unityVersion: ${{ fromJson(VARS.CI_UNITY_VERSIONS) }}
+
+    steps:
+      - name: Checkout unity-sdk repository
+        uses: actions/checkout@v5
+        with:
+          path: unity-sdk
+
+      - name: Checkout unity-sdk-packager-project repository
+        uses: actions/checkout@v5
+        with:
+          repository: lootlocker/unity-sdk-packager
+          path: unity-sdk-packager
+          token: ${{ SECRETS.LL_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Add LootLockerSDK as asset folder
+        run: |
+          cp -r unity-sdk unity-sdk-packager/Assets/LootLockerSDK
+
+      - uses: actions/cache@v4
+        with:
+          path: unity-sdk-packager/Library
+          key: package-sdk-Library-${{ matrix.unityVersion }}
+          restore-keys: |
+            package-sdk-Library-
+            Library-
+
+      - name: Package SDK for ${{ matrix.unityVersion }}
+        id: package-sdk-gameci
+        uses: game-ci/unity-test-runner@v4.3.1
+        env:
+          UNITY_LICENSE: ${{ SECRETS.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ SECRETS.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ SECRETS.UNITY_PASSWORD }}
+        with:
+          testMode: editmode
+          checkName: SDK Packaging ${{ matrix.unityVersion }} Results
+          artifactsPath: package-sdk-${{ matrix.unityVersion }}-artifacts
+          projectPath: unity-sdk-packager
+          unityVersion: ${{ matrix.unityVersion }}
+          githubToken: ${{ SECRETS.GITHUB_TOKEN }}
+
+      - name: Attach .unitypackage to release
+        run: |
+          for f in unity-sdk-packager/LootLockerSDK*.unitypackage; do
+            echo "Uploading $f"
+            gh release upload --clobber "${{ github.ref_name }}" "$f"
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload package as workflow artifact (fallback)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: LootLockerSDK-${{ matrix.unityVersion }}
+          path: unity-sdk-packager/LootLockerSDK*.unitypackage

--- a/.github/workflows/run-tests-ci.yml
+++ b/.github/workflows/run-tests-ci.yml
@@ -1,5 +1,5 @@
-name: Run Tests and Package SDK
-run-name: Run Tests and Package SDK on ${{ github.ref_name }} because of ${{ github.event_name }} with commit ${{ github.sha }}
+name: Run Tests
+run-name: Run Tests on ${{ github.ref_name }} because of ${{ github.event_name }} with commit ${{ github.sha }}
 on:
   pull_request:
     branches: # Made towards the following
@@ -20,7 +20,7 @@ on:
         default: "localhost:8080"
 
 concurrency:
-  group: run-tests-and-package-${{ github.ref }}
+  group: run-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -723,77 +723,4 @@ jobs:
           projectPath: unity-sdk-package-validator
           unityVersion: ${{ matrix.unityVersion }}
           githubToken: ${{ SECRETS.GITHUB_TOKEN }}
-  package-sdk:
-    name: Package SDK
-    runs-on: [ubuntu-latest]
-    needs: [test-samples, run-integration-tests]
-    timeout-minutes: 5
-    if: (startsWith(github.ref, 'refs/pull') && endsWith(github.base_ref, 'main')) || (startsWith(github.ref, 'refs/heads') && endsWith(github.ref, 'main')) || startsWith(github.ref, 'refs/tags/v')
-    env: 
-      LL_USE_STAGE: false
-    strategy:
-      fail-fast: false
-      matrix:
-        unityVersion: ${{ fromJson(VARS.CI_UNITY_VERSIONS) }}
-    steps:
-      - name: Setup commandline dependencies (if on self-hosted runner)
-        if: ${{ env.LL_USE_STAGE == 'true' }}
-        run: |
-          apt update
-          apt-get install -y git
-          git config --global --add safe.directory unity-sdk
-          git config --global --add safe.directory unity-sdk-packager
-          apt-get install -y jq
-          apt-get install -y sed
-          apt-get install -y docker
-          apt-get install -y curl
-          apt-get update
-          apt-get install ca-certificates curl gnupg
-          install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          chmod a+r /etc/apt/keyrings/docker.gpg
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            tee /etc/apt/sources.list.d/docker.list > /dev/null
-          apt-get update
-          apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-      - name: Checkout unity-sdk repository
-        uses: actions/checkout@v5
-        with:
-          path: unity-sdk
-      - name: Checkout unity-sdk-packager-project repository
-        uses: actions/checkout@v5
-        with:
-          repository: lootlocker/unity-sdk-packager
-          path: unity-sdk-packager
-          token: ${{ SECRETS.LL_PERSONAL_ACCESS_TOKEN }}
-      - name: Add LootLockerSDK as asset folder
-        run: |
-          cp -r unity-sdk unity-sdk-packager/Assets/LootLockerSDK
-      - uses: actions/cache@v4
-        with:
-          path: unity-sdk-packager/Library
-          key: ${{ matrix.targetPlatform }}-Library-unity-sdk-packager
-          restore-keys: |
-            ${{ matrix.targetPlatform }}-Library-unity-sdk-packager
-            Library-
-      - name: Package SDK for ${{ matrix.unityVersion }}
-        id: package-sdk-gameci
-        uses: game-ci/unity-test-runner@v4.3.1
-        env:
-          UNITY_LICENSE: ${{ SECRETS.UNITY_LICENSE }}
-          UNITY_EMAIL: ${{ SECRETS.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ SECRETS.UNITY_PASSWORD }}
-        with:
-          testMode: editmode
-          checkName: SDK Packaging ${{ matrix.unityVersion }} Results
-          artifactsPath: package-sdk-${{ matrix.unityVersion }}-artifacts
-          projectPath: unity-sdk-packager
-          unityVersion: ${{ matrix.unityVersion }}
-          githubToken: ${{ SECRETS.GITHUB_TOKEN }}
-      - name: Expose packaged SDK as artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: LootLockerSDK-${{ matrix.unityVersion }}.zip
-          path: unity-sdk-packager/LootLockerSDK*.unitypackage
+


### PR DESCRIPTION
## Tracking issue

Closes lootlocker/index#1572

## Description

Automates the Unity SDK release process with four new workflows and one refactored existing workflow. The full release pipeline is:

1. `open-release-pr.yml` — `workflow_dispatch` that bumps version (auto via OpenRouter DeepSeek V4 Pro, or manual major/minor/patch/custom), writes release notes (AI-generated or template), and opens a `release candidate` PR from dev to main
2. `enforce-release-pr.yml` — validates release candidate PRs have a version bump, non-empty body with `###` section headers, and warns on missing `Full Changelog:` link
3. `run-tests-ci.yml` (renamed from `run-tests-and-package.yml`) — runs the full CI suite on push to main; packaging job removed (moved to separate workflow)
4. `create-release.yml` — fires automatically after `Run Tests` passes on main, or via `workflow_dispatch` with PR number. Finds the release candidate PR, reads version from `package.json`, validates bump, creates tag + GitHub Release with PR body as release notes
5. `package-sdk.yml` — triggers on `release: published`, builds `.unitypackage` files for each Unity version and attaches them to the release

The existing `sign-package.yml` and `generate-docs.yml` already trigger on `release: published` and work without changes.

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs
- [ ] Chore

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Branch follows naming convention (`task/1572-automate-sdk-releases`)
- [x] Diff is minimal and scoped — no unrelated changes, no drive-by refactors
- [x] No version bumps or release metadata changes
- [x] No new helpers/utilities introduced without first searching for existing ones
- [ ] Compile Check CI workflow passes (or verification has been run locally)
- [x] Runtime code has no unguarded `UnityEditor` dependencies
- [x] Editor-only code is placed under `Runtime/Editor/` and/or guarded with `#if UNITY_EDITOR`
- [x] Tracking issue in `lootlocker/index` is linked and status set to "In Review"

## Testing notes

All four new workflows are YAML-only (no C# changes). Verified:
- `package-sdk.yml` structural review — matches the extracted packaging job from `run-tests-and-package.yml` exactly (minus the self-hosted runner setup which isn't needed on `release: published`)
- `create-release.yml` manual dispatch path uses `gh pr view` to fetch PR data — same API patterns used elsewhere in the repo
- `enforce-release-pr.yml` label check uses `contains(github.event.pull_request.labels.*.name, 'release candidate')` — standard GitHub Actions pattern
- `open-release-pr.yml` AI prompts tested locally against actual `v8.0.0..origin/dev` commits:
  - Version detection: DeepSeek V4 Pro correctly returned `9.0.0` (identified breaking changes)
  - Release notes generation: produced structured Features/Fixes/Breaking Changes sections
- `run-tests-ci.yml` rename verified with `git mv` — tracked as a rename, not a delete+create

## Additional notes

Requires one new secret: `OPENROUTER_API_KEY` — for AI-powered version detection and release notes in `open-release-pr.yml`. The workflow falls back to manual bump + static template if the secret is missing.

The `release candidate` label already exists on the repo (visible on issues). No label creation needed.

Unreal SDK and Unreal Server SDK automation is out of scope for this PR — tracked for future work in the same issue.
