### PR TITLE
Add List Platform Keys endpoint

### DIFF
--- a/.doxygen/groups.dox
+++ b/.doxygen/groups.dox
@@ -214,6 +214,15 @@
 ///
 /// See the [LootLocker documentation](https://docs.lootlocker.com/commerce/wallets).
 
+/// @defgroup PlatformKeys Platform Keys
+/// @brief List platform keys redeemed by the authenticated player.
+///
+/// Platform keys are keys distributed through LootLocker's Campaign system
+/// (e.g. Steam keys, Discord keys). This endpoint returns all keys redeemed
+/// by the currently authenticated player, grouped by campaign.
+///
+/// See the [LootLocker documentation](https://docs.lootlocker.com/campaigns/overview).
+
 /// @defgroup Catalog Catalog
 /// @brief Browse item listings and prices in the LootLocker storefront catalog.
 ///

--- a/Runtime/Client/LootLockerEndPoints.cs
+++ b/Runtime/Client/LootLockerEndPoints.cs
@@ -253,6 +253,10 @@ namespace LootLocker
         public static EndPointClass getCurrencyDetails = new EndPointClass("currency/code/{0}", LootLockerHTTPMethod.GET);
         public static EndPointClass getCurrencyDenominationsByCode = new EndPointClass("currency/code/{0}/denominations", LootLockerHTTPMethod.GET);
 
+        // Platform Keys
+        [Header("Platform Keys")]
+        public static EndPointClass listPlatformKeys = new EndPointClass("platform-keys/v1", LootLockerHTTPMethod.GET);
+
         // Balances
         [Header("Balances")]
         public static EndPointClass listBalancesInWallet = new EndPointClass("balances/wallet/{0}", LootLockerHTTPMethod.GET);

--- a/Runtime/Game/LootLockerSDKManager.cs
+++ b/Runtime/Game/LootLockerSDKManager.cs
@@ -9046,6 +9046,25 @@ namespace LootLocker.Requests
 
         #endregion
 
+        #region Platform Keys
+        /// @ingroup PlatformKeys
+        /// <summary>
+        /// Get a list of the platform keys redeemed by the authenticated player
+        /// </summary>
+        /// <param name="onComplete">onComplete Action for handling the response</param>
+        /// <param name="forPlayerWithUlid">Optional : Execute the request for the specified player. If not supplied, the default player will be used.</param>
+        public static void ListPlatformKeys(Action<LootLockerListPlatformKeysResponse> onComplete, string forPlayerWithUlid = null)
+        {
+            if (!CheckInitialized(false, forPlayerWithUlid))
+            {
+                onComplete?.Invoke(LootLockerResponseFactory.SDKNotInitializedError<LootLockerListPlatformKeysResponse>(forPlayerWithUlid));
+                return;
+            }
+
+            LootLockerServerRequest.CallAPI(forPlayerWithUlid, LootLockerEndPoints.listPlatformKeys.endPoint, LootLockerEndPoints.listPlatformKeys.httpMethod, onComplete: (serverResponse) => { LootLockerResponse.Deserialize(onComplete, serverResponse); });
+        }
+        #endregion
+
         #region Balances
         /// @ingroup Balances
         /// <summary>

--- a/Runtime/Game/Requests/PlatformKeyRequests.cs
+++ b/Runtime/Game/Requests/PlatformKeyRequests.cs
@@ -1,0 +1,52 @@
+namespace LootLocker.Requests
+{
+    //==================================================
+    // Data Definitions
+    //==================================================
+
+    /// <summary>
+    /// Information about the campaign associated with a platform key
+    /// </summary>
+    public class LootLockerPlatformKeyCampaign
+    {
+        /// <summary>
+        /// The name of the campaign that issued this key
+        /// </summary>
+        public string name { get; set; }
+        /// <summary>
+        /// The platform this key is for (e.g. "steam", "discord")
+        /// </summary>
+        public string platform { get; set; }
+    };
+
+    /// <summary>
+    /// A platform key redeemed by the player
+    /// </summary>
+    public class LootLockerPlatformKey
+    {
+        /// <summary>
+        /// Information about the campaign that issued this key
+        /// </summary>
+        public LootLockerPlatformKeyCampaign campaign { get; set; }
+        /// <summary>
+        /// The redeemed key value
+        /// </summary>
+        public string key { get; set; }
+    };
+
+    //==================================================
+    // Response Definitions
+    //==================================================
+
+    /// <summary>
+    /// Response containing all platform keys redeemed by the authenticated player.
+    /// </summary>
+    public class LootLockerListPlatformKeysResponse : LootLockerResponse
+    {
+        /// <summary>
+        /// List of platform keys redeemed by the player
+        /// </summary>
+        public LootLockerPlatformKey[] platform_keys { get; set; }
+    };
+
+}

--- a/Runtime/Game/Requests/PlatformKeyRequests.cs.meta
+++ b/Runtime/Game/Requests/PlatformKeyRequests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db18f465c3edca84dacafe89af3a3ab3

--- a/Runtime/Game/Requests/PlatformKeyRequests.cs.meta
+++ b/Runtime/Game/Requests/PlatformKeyRequests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: db18f465c3edca84dacafe89af3a3ab3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds support for `GET /game/platform-keys/v1` returning platform keys redeemed by the authenticated player.

### Changes
- **New DTOs** (`PlatformKeyRequests.cs`): `LootLockerPlatformKeyCampaign`, `LootLockerPlatformKey`, `LootLockerListPlatformKeysResponse`
- **New endpoint** in `LootLockerEndPoints`: `listPlatformKeys`
- **New SDKManager method**: `ListPlatformKeys(Action<..., string forPlayerWithUlid = null)`

### API
```
GET /game/platform-keys/v1
Response: { "platform_keys": [{ "campaign": { "name": "...", "platform": "..." }, "key": "..." }] }
```

Closes lootlocker/index#1530